### PR TITLE
Add theme toggle and improve accessibility

### DIFF
--- a/app/templates/admin/trainers.html
+++ b/app/templates/admin/trainers.html
@@ -5,9 +5,9 @@
   <form method="POST" class="mb-4">
     {{ form.hidden_tag() }}
     <div class="row g-2">
-      <div class="col-md-3">{{ form.first_name(class="form-control", placeholder="Imię") }}</div>
-      <div class="col-md-3">{{ form.last_name(class="form-control", placeholder="Nazwisko") }}</div>
-      <div class="col-md-3">{{ form.phone_number(class="form-control", placeholder="Telefon") }}</div>
+      <div class="col-md-3">{{ form.first_name(class="form-control", placeholder="Imię", aria_label="Imię") }}</div>
+      <div class="col-md-3">{{ form.last_name(class="form-control", placeholder="Nazwisko", aria_label="Nazwisko") }}</div>
+      <div class="col-md-3">{{ form.phone_number(class="form-control", placeholder="Telefon", aria_label="Telefon") }}</div>
       <div class="col-md-3"><button class="btn btn-success w-100">Dodaj trenera</button></div>
     </div>
   </form>

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -11,9 +11,9 @@
   <form method="POST" class="mb-4">
     {{ form.hidden_tag() }}
     <div class="row g-2">
-      <div class="col-md-3">{{ form.date(class="form-control") }}</div>
-      <div class="col-md-3">{{ form.location(class="form-control", placeholder="Miejsce") }}</div>
-      <div class="col-md-3">{{ form.coach_id(class="form-select") }}</div>
+      <div class="col-md-3">{{ form.date(class="form-control", aria_label="Data i godzina treningu") }}</div>
+      <div class="col-md-3">{{ form.location(class="form-control", placeholder="Miejsce", aria_label="Miejsce") }}</div>
+      <div class="col-md-3">{{ form.coach_id(class="form-select", aria_label="Trener") }}</div>
       <div class="col-md-3"><button class="btn btn-success w-100">Dodaj trening</button></div>
     </div>
   </form>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,7 +25,10 @@
           <small>na treningi blind tenisa</small>
         </div>
       </div>
-      <a href="{{ url_for('admin.manage_trainers') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+      <div class="d-flex align-items-center gap-2">
+        <a href="{{ url_for('admin.manage_trainers') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+        <button id="theme-toggle" type="button" class="btn btn-outline-light btn-sm" aria-label="Przełącz motyw">🌓</button>
+      </div>
     </div>
   </header>
 
@@ -33,9 +36,9 @@
   <main class="flex-grow-1">
     {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
-        <div class="container mt-3">
+        <div class="container mt-3" aria-live="polite">
           {% for category, message in messages %}
-            <div class="alert alert-{{ category }}">{{ message }}</div>
+            <div class="alert alert-{{ category }}" role="alert">{{ message }}</div>
           {% endfor %}
         </div>
       {% endif %}
@@ -52,6 +55,22 @@
       <img src="https://vestmedia.pl/wp-content/uploads/2024/12/Vest-Media-5.png" alt="Vest Media" class="footer-logo">
     </div>
   </footer>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const body = document.body;
+      const toggleBtn = document.getElementById('theme-toggle');
+      const stored = localStorage.getItem('theme');
+      if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        body.classList.add('dark-mode');
+      }
+      toggleBtn.addEventListener('click', function () {
+        body.classList.toggle('dark-mode');
+        const isDark = body.classList.contains('dark-mode');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    });
+  </script>
 
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,9 +32,9 @@
             {% if training.bookings|length < 2 %}
               <form method="post" class="d-inline">
                 {{ form.hidden_tag() }}
-                {{ form.first_name(class="form-control mb-1", placeholder="Imię") }}
-                {{ form.last_name(class="form-control mb-1", placeholder="Nazwisko") }}
-                {{ form.phone_number(class="form-control mb-1", placeholder="Telefon") }}
+                {{ form.first_name(class="form-control mb-1", placeholder="Imię", aria_label="Imię") }}
+                {{ form.last_name(class="form-control mb-1", placeholder="Nazwisko", aria_label="Nazwisko") }}
+                {{ form.phone_number(class="form-control mb-1", placeholder="Telefon", aria_label="Telefon") }}
                 {{ form.training_id(value=training.id) }}
                 <button type="submit" class="btn btn-sm btn-primary">Zapisz się</button>
               </form>

--- a/static/style.css
+++ b/static/style.css
@@ -17,34 +17,35 @@ a {
   color: var(--link-color-light);
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: var(--bg-color-dark);
-    color: var(--text-color-dark);
-  }
+body.dark-mode {
+  background-color: var(--bg-color-dark);
+  color: var(--text-color-dark);
+}
 
-  a {
-    color: var(--link-color-dark);
-  }
+body.dark-mode a {
+  color: var(--link-color-dark);
+}
 
-  .table, .form-control, .form-select, .btn {
-    background-color: #2a2a40;
-    color: var(--text-color-dark);
-  }
+body.dark-mode .table,
+body.dark-mode .form-control,
+body.dark-mode .form-select,
+body.dark-mode .btn {
+  background-color: #2a2a40;
+  color: var(--text-color-dark);
+}
 
-  .table thead {
-    background-color: #343a40;
-  }
+body.dark-mode .table thead {
+  background-color: #343a40;
+}
 
-  .btn-outline-light {
-    border-color: #ffa500;
-    color: #ffa500;
-  }
+body.dark-mode .btn-outline-light {
+  border-color: #ffa500;
+  color: #ffa500;
+}
 
-  .btn-outline-light:hover {
-    background-color: #ffa500;
-    color: #1e1e2f;
-  }
+body.dark-mode .btn-outline-light:hover {
+  background-color: #ffa500;
+  color: #1e1e2f;
 }
 
 table a {


### PR DESCRIPTION
## Summary
- allow users to toggle light and dark themes with stored preference
- wrap flash messages in an aria-live region
- add aria labels to volunteer and admin forms
- style `.dark-mode` for custom themes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872604d2b44832ab5306b2b9b1f381c