### PR TITLE
Update Flask-WTF to >=1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.3.3
 Flask-SQLAlchemy==3.1.1
-Flask-WTF==1.1.1
+Flask-WTF>=1.2.2
 WTForms==3.1.1
 python-dotenv==1.0.1
 openpyxl==3.1.2


### PR DESCRIPTION
## Summary
- loosen Flask-WTF version requirement
- install updated dependencies

## Testing
- `pip install -r requirements.txt`
- `python run.py`

------
https://chatgpt.com/codex/tasks/task_e_6872660f9460832abbb334ecf5dd65c8