### PR TITLE
Remove .env from repository

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-FLASK_ENV=development
-SECRET_KEY=supersekretnyklucz
-ADMIN_PASSWORD=haslotrenera123

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+FLASK_ENV=development
+SECRET_KEY=your-secret-key
+ADMIN_PASSWORD=your-admin-password

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+*.env
 .env
 .envrc
 .venv

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project provides a simple web application for organizing blind tennis train
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. Set environment variables (see `.env` for an example). Required variables are:
+2. Set environment variables (see `.env.example` for an example). Required variables are:
    - `SECRET_KEY` – Flask secret key.
    - `ADMIN_PASSWORD` – password for the admin panel.
    Optional variables include `FLASK_ENV` and `FLASK_APP`.


### PR DESCRIPTION
## Summary
- remove .env from tracking
- document environment variables in README
- add .env.example
- keep all .env variants ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687266da11b0832ab768e64c5d2cba3c