### PR TITLE
Fix aria label attributes in forms

### DIFF
--- a/app/templates/admin/trainers.html
+++ b/app/templates/admin/trainers.html
@@ -5,9 +5,9 @@
   <form method="POST" class="mb-4">
     {{ form.hidden_tag() }}
     <div class="row g-2">
-      <div class="col-md-3">{{ form.first_name(class="form-control", placeholder="Imię", aria_label="Imię") }}</div>
-      <div class="col-md-3">{{ form.last_name(class="form-control", placeholder="Nazwisko", aria_label="Nazwisko") }}</div>
-      <div class="col-md-3">{{ form.phone_number(class="form-control", placeholder="Telefon", aria_label="Telefon") }}</div>
+      <div class="col-md-3">{{ form.first_name(class="form-control", placeholder="Imię", **{'aria-label': 'Imię'}) }}</div>
+      <div class="col-md-3">{{ form.last_name(class="form-control", placeholder="Nazwisko", **{'aria-label': 'Nazwisko'}) }}</div>
+      <div class="col-md-3">{{ form.phone_number(class="form-control", placeholder="Telefon", **{'aria-label': 'Telefon'}) }}</div>
       <div class="col-md-3"><button class="btn btn-success w-100">Dodaj trenera</button></div>
     </div>
   </form>

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -11,9 +11,9 @@
   <form method="POST" class="mb-4">
     {{ form.hidden_tag() }}
     <div class="row g-2">
-      <div class="col-md-3">{{ form.date(class="form-control", aria_label="Data i godzina treningu") }}</div>
-      <div class="col-md-3">{{ form.location(class="form-control", placeholder="Miejsce", aria_label="Miejsce") }}</div>
-      <div class="col-md-3">{{ form.coach_id(class="form-select", aria_label="Trener") }}</div>
+      <div class="col-md-3">{{ form.date(class="form-control", **{'aria-label': 'Data i godzina treningu'}) }}</div>
+      <div class="col-md-3">{{ form.location(class="form-control", placeholder="Miejsce", **{'aria-label': 'Miejsce'}) }}</div>
+      <div class="col-md-3">{{ form.coach_id(class="form-select", **{'aria-label': 'Trener'}) }}</div>
       <div class="col-md-3"><button class="btn btn-success w-100">Dodaj trening</button></div>
     </div>
   </form>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,9 +32,9 @@
             {% if training.bookings|length < 2 %}
               <form method="post" class="d-inline">
                 {{ form.hidden_tag() }}
-                {{ form.first_name(class="form-control mb-1", placeholder="Imię", aria_label="Imię") }}
-                {{ form.last_name(class="form-control mb-1", placeholder="Nazwisko", aria_label="Nazwisko") }}
-                {{ form.phone_number(class="form-control mb-1", placeholder="Telefon", aria_label="Telefon") }}
+                {{ form.first_name(class="form-control mb-1", placeholder="Imię", **{'aria-label': 'Imię'}) }}
+                {{ form.last_name(class="form-control mb-1", placeholder="Nazwisko", **{'aria-label': 'Nazwisko'}) }}
+                {{ form.phone_number(class="form-control mb-1", placeholder="Telefon", **{'aria-label': 'Telefon'}) }}
                 {{ form.training_id(value=training.id) }}
                 <button type="submit" class="btn btn-sm btn-primary">Zapisz się</button>
               </form>


### PR DESCRIPTION
## Summary
- replace `aria_label` arguments in form fields with `**{'aria-label': ...}`
- keep behaviour in index, trainers, and trainings templates

## Testing
- `python - <<'PY'
import os
from app import create_app, db
from app.models import Coach, Training
from datetime import datetime

os.environ['SECRET_KEY'] = 'test'
os.environ['ADMIN_PASSWORD'] = 'pass'
app = create_app()
app.config['WTF_CSRF_ENABLED'] = False

with app.app_context():
    db.drop_all(); db.create_all();
    coach = Coach(first_name='Jan', last_name='Kowalski', phone_number='123')
    db.session.add(coach); db.session.commit()
    training = Training(date=datetime.now(), location='Place', coach_id=coach.id)
    db.session.add(training); db.session.commit()

with app.test_client() as c:
    r = c.get('/')
    assert r.status_code == 200 and 'aria-label="Imię"' in r.get_data(as_text=True)
    c.post('/admin/login', data={'password': 'pass'}, follow_redirects=True)
    r = c.get('/admin/trainers')
    assert r.status_code == 200 and 'aria-label="Imię"' in r.get_data(as_text=True)
    r = c.get('/admin/trainings')
    assert r.status_code == 200 and 'aria-label="Data i godzina treningu"' in r.get_data(as_text=True)
PY

------
https://chatgpt.com/codex/tasks/task_e_68726763b7ec832aa9c2247a9fc36e7b