### PR TITLE
Implement admin login form with CSRF support

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -12,7 +12,7 @@ from functools import wraps
 from datetime import datetime
 
 from . import db
-from .forms import CoachForm, TrainingForm
+from .forms import CoachForm, TrainingForm, LoginForm
 from .models import Coach, Training
 
 admin_bp = Blueprint("admin", __name__)
@@ -29,14 +29,16 @@ def login_required(view):
 
 @admin_bp.route("/login", methods=["GET", "POST"])
 def login():
-    if request.method == "POST":
-        password = request.form.get("password")
-        if password == current_app.config["ADMIN_PASSWORD"]:
+    form = LoginForm()
+
+    if form.validate_on_submit():
+        if form.password.data == current_app.config["ADMIN_PASSWORD"]:
             session["admin_logged_in"] = True
             flash("Zalogowano jako administrator.", "success")
             return redirect(url_for("admin.manage_trainers"))
         flash("Nieprawidłowe hasło.", "danger")
-    return render_template("admin/login.html")
+
+    return render_template("admin/login.html", form=form)
 
 
 @admin_bp.route("/logout")

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,5 +1,11 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, SubmitField, DateTimeField, SelectField
+from wtforms import (
+    StringField,
+    SubmitField,
+    DateTimeField,
+    SelectField,
+    PasswordField,
+)
 from wtforms.validators import DataRequired, Length
 from wtforms.fields import HiddenField
 
@@ -44,3 +50,8 @@ class VolunteerForm(FlaskForm):
     )
     training_id = HiddenField()  # ukryte pole – ID treningu
     submit = SubmitField('Zapisz się')
+
+
+class LoginForm(FlaskForm):
+    password = PasswordField('Hasło', validators=[DataRequired()])
+    submit = SubmitField('Zaloguj się')

--- a/app/templates/admin/login.html
+++ b/app/templates/admin/login.html
@@ -3,11 +3,12 @@
 <div class="container mt-5" style="max-width: 500px;">
   <h2 class="mb-3">Logowanie administratora</h2>
   <form method="POST">
+    {{ form.hidden_tag() }}
     <div class="mb-3">
-      <label for="password" class="form-label">Hasło</label>
-      <input type="password" name="password" id="password" class="form-control" required>
+      {{ form.password.label(class="form-label") }}
+      {{ form.password(class="form-control", required=True) }}
     </div>
-    <button class="btn btn-primary w-100">Zaloguj się</button>
+    {{ form.submit(class="btn btn-primary w-100") }}
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `LoginForm` with password field
- use the form in `/admin/login`
- render `form.hidden_tag()` and form fields in login template

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `python - <<'PYTHON'
import os
os.environ['ADMIN_PASSWORD']='secret'
from app import create_app
from bs4 import BeautifulSoup
app=create_app()
client=app.test_client()
resp=client.post('/admin/login', data={'password':'secret'})
print('POST status', resp.status)
csrf_token=BeautifulSoup(client.get('/admin/login').data,'html.parser').find('input',{'id':'csrf_token'})['value']
resp=client.post('/admin/login', data={'password':'secret','csrf_token':csrf_token}, follow_redirects=True)
print('Final status', resp.status)
print('logged in message', 'Zalogowano jako administrator.' in resp.get_data(as_text=True))
PYTHON

------
https://chatgpt.com/codex/tasks/task_e_6872798cfae4832a8893ce51534ee373