### PR TITLE
Add Excel import and location model

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -6,6 +6,7 @@ from wtforms import (
     SelectField,
     PasswordField,
 )
+from flask_wtf.file import FileField
 from wtforms.validators import DataRequired, Length
 from wtforms.fields import HiddenField
 
@@ -29,8 +30,8 @@ class TrainingForm(FlaskForm):
         format='%Y-%m-%d %H:%M',
         validators=[DataRequired()],
     )
-    location = StringField(
-        'Miejsce', validators=[DataRequired(), Length(max=128)]
+    location_id = SelectField(
+        'Miejsce', coerce=int, validators=[DataRequired()]
     )
     coach_id = SelectField(
         'Trener', coerce=int, validators=[DataRequired()]
@@ -55,3 +56,8 @@ class VolunteerForm(FlaskForm):
 class LoginForm(FlaskForm):
     password = PasswordField('Hasło', validators=[DataRequired()])
     submit = SubmitField('Zaloguj się')
+
+
+class ImportTrainingsForm(FlaskForm):
+    file = FileField('Plik Excel', validators=[DataRequired()])
+    submit = SubmitField('Importuj')

--- a/app/models.py
+++ b/app/models.py
@@ -13,25 +13,37 @@ class Coach(db.Model):
         return f"<Coach {self.first_name} {self.last_name}>"
 
 
+class Location(db.Model):
+    __tablename__ = 'locations'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), unique=True, nullable=False)
+
+    def __repr__(self):
+        return f"<Location {self.name}>"
+
+
 class Training(db.Model):
     __tablename__ = 'trainings'
     id = db.Column(db.Integer, primary_key=True)
     date = db.Column(db.DateTime, nullable=False)
-    location = db.Column(db.String(128), nullable=False)
+    location_id = db.Column(
+        db.Integer,
+        db.ForeignKey('locations.id'),
+        nullable=False,
+    )
     coach_id = db.Column(
         db.Integer,
         db.ForeignKey('coaches.id'),
         nullable=False,
     )
 
-    coach = db.relationship(
-        'Coach', backref=db.backref('trainings', lazy=True)
-    )
+    coach = db.relationship('Coach', backref=db.backref('trainings', lazy=True))
+    location = db.relationship('Location', backref=db.backref('trainings', lazy=True))
 
     def __repr__(self):
         return (
             f"<Training {self.date.strftime('%Y-%m-%d %H:%M')} at "
-            f"{self.location}>"
+            f"{self.location.name}>"
         )
 
 

--- a/app/templates/admin/import.html
+++ b/app/templates/admin/import.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-4" style="max-width: 500px;">
+  <h2>Importuj treningi</h2>
+  <form method="POST" enctype="multipart/form-data">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">{{ form.file.label }} {{ form.file(class="form-control") }}</div>
+    <button class="btn btn-primary">Importuj</button>
+    <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-secondary ms-2">Anuluj</a>
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -3,8 +3,11 @@
 <div class="container mt-4">
   <h2>Treningi</h2>
 <div class="d-flex justify-content-end mb-3">
-  <a href="{{ url_for('admin.export_excel') }}" class="btn btn-outline-primary">
+  <a href="{{ url_for('admin.export_excel') }}" class="btn btn-outline-primary me-2">
     📥 Eksportuj do Excela
+  </a>
+  <a href="{{ url_for('admin.import_excel') }}" class="btn btn-outline-success">
+    📤 Importuj z Excela
   </a>
 </div>
 
@@ -12,7 +15,7 @@
     {{ form.hidden_tag() }}
     <div class="row g-2">
       <div class="col-md-3">{{ form.date(class="form-control", **{'aria-label': 'Data i godzina treningu'}) }}</div>
-      <div class="col-md-3">{{ form.location(class="form-control", placeholder="Miejsce", **{'aria-label': 'Miejsce'}) }}</div>
+      <div class="col-md-3">{{ form.location_id(class="form-select", **{'aria-label': 'Miejsce'}) }}</div>
       <div class="col-md-3">{{ form.coach_id(class="form-select", **{'aria-label': 'Trener'}) }}</div>
       <div class="col-md-3"><button class="btn btn-success w-100">Dodaj trening</button></div>
     </div>
@@ -24,7 +27,7 @@
       {% for t in trainings %}
       <tr>
         <td>{{ t.date.strftime('%Y-%m-%d %H:%M') }}</td>
-        <td>{{ t.location }}</td>
+        <td>{{ t.location.name }}</td>
         <td>{{ t.coach.first_name }} {{ t.coach.last_name }}</td>
       </tr>
       {% endfor %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,7 +19,7 @@
         {% for training in trainings %}
         <tr>
           <td>{{ training.date.strftime('%Y-%m-%d %H:%M') }}</td>
-          <td>{{ training.location }}</td>
+          <td>{{ training.location.name }}</td>
           <td>{{ training.coach.first_name }} {{ training.coach.last_name }}<br><small>{{ training.coach.phone_number }}</small></td>
           <td>
             <ul class="mb-0">


### PR DESCRIPTION
## Summary
- create `Location` model and use it from `Training`
- switch training form to select existing locations
- provide Excel import form for trainings
- allow admins to import trainings from Excel
- show location names in templates and add import button

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python run.py & sleep 5; kill $!; sleep 1`

------
https://chatgpt.com/codex/tasks/task_e_68727caf4b1c832abb059831f6e13887