### PR TITLE
Add admin training history page

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -271,3 +271,19 @@ def import_excel():
         return redirect(url_for("admin.manage_trainings"))
 
     return render_template("admin/import.html", form=form)
+
+
+@admin_bp.route("/history")
+@login_required
+def history():
+    """List past trainings with volunteer sign-ups."""
+    page = request.args.get("page", 1, type=int)
+    trainings_q = Training.query.filter(
+        Training.date < datetime.now()
+    ).order_by(Training.date.desc())
+    pagination = db.paginate(trainings_q, page=page, per_page=10)
+    return render_template(
+        "admin/history.html",
+        trainings=pagination.items,
+        pagination=pagination,
+    )

--- a/app/templates/admin/history.html
+++ b/app/templates/admin/history.html
@@ -1,0 +1,50 @@
+{% extends "admin/admin_base.html" %}
+{% block admin_content %}
+<div class="container mt-4">
+  <h2>Historia treningów</h2>
+  <table class="table table-bordered table-sm mt-3">
+    <thead class="table-light">
+      <tr>
+        <th>Data</th>
+        <th>Miejsce</th>
+        <th>Trener</th>
+        <th>Wolontariusze</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for t in trainings %}
+      <tr>
+        <td>{{ t.date.strftime('%Y-%m-%d %H:%M') }}</td>
+        <td>{{ t.location.name }}</td>
+        <td>{{ t.coach.first_name }} {{ t.coach.last_name }}<br><small>{{ t.coach.phone_number }}</small></td>
+        <td>
+          <ul class="mb-0">
+            {% for b in t.bookings %}
+              <li>{{ b.volunteer.first_name }} {{ b.volunteer.last_name }}</li>
+            {% endfor %}
+          </ul>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {% if pagination.pages > 1 %}
+  <nav aria-label="Paginacja">
+    <ul class="pagination">
+      <li class="page-item {% if not pagination.has_prev %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('admin.history', page=pagination.prev_num) }}" aria-label="Poprzednia">&laquo;</a>
+      </li>
+      {% for p in range(1, pagination.pages + 1) %}
+      <li class="page-item {% if p == pagination.page %}active{% endif %}">
+        <a class="page-link" href="{{ url_for('admin.history', page=p) }}">{{ p }}</a>
+      </li>
+      {% endfor %}
+      <li class="page-item {% if not pagination.has_next %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('admin.history', page=pagination.next_num) }}" aria-label="Następna">&raquo;</a>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- show past trainings in `/admin/history`
- list training date, location, coach and volunteers
- include pagination for long history

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import os
os.environ['ADMIN_PASSWORD']='test'
from app import create_app
app = create_app(); app.config['WTF_CSRF_ENABLED']=False
with app.test_client() as c:
    c.post('/admin/login', data={'password':'test'}, follow_redirects=True)
    r=c.get('/admin/history'); print(r.status_code); print('<table' in r.data.decode())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68728a06d8d8832a9ea5e9518f9ee868