### PR TITLE
Show upcoming trainings grouped by month

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -144,7 +144,14 @@ def manage_trainings():
     form.location_id.choices = [
         (l.id, l.name) for l in Location.query.order_by(Location.name).all()
     ]
-    trainings = Training.query.order_by(Training.date).all()
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    trainings_q = Training.query.filter(Training.date >= today).order_by(Training.date)
+    trainings = trainings_q.all()
+
+    trainings_by_month = {}
+    for t in trainings:
+        month_key = t.date.strftime("%Y-%m")
+        trainings_by_month.setdefault(month_key, []).append(t)
 
     if form.validate_on_submit():
         new_training = Training(
@@ -160,7 +167,7 @@ def manage_trainings():
     return render_template(
         "admin/trainings.html",
         form=form,
-        trainings=trainings,
+        trainings_by_month=trainings_by_month,
     )
 
 

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -21,17 +21,40 @@
     </div>
   </form>
 
-  <table class="table table-striped">
-    <thead><tr><th>Data</th><th>Miejsce</th><th>Trener</th></tr></thead>
-    <tbody>
-      {% for t in trainings %}
+  {% for month, ts in trainings_by_month.items() %}
+  <h4 class="mt-4">{{ month|replace("-", " / ") }}</h4>
+  <table class="table table-striped table-sm">
+    <thead>
       <tr>
-        <td>{{ t.date.strftime('%Y-%m-%d %H:%M') }}</td>
+        <th>Data</th>
+        <th>Godzina</th>
+        <th>Miejsce</th>
+        <th>Trener</th>
+        <th>Telefon trenera</th>
+        <th>Wolontariusz 1</th>
+        <th>Wolontariusz 2</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for t in ts %}
+      <tr>
+        <td>{{ t.date.strftime('%Y-%m-%d') }}</td>
+        <td>{{ t.date.strftime('%H:%M') }}</td>
         <td>{{ t.location.name }}</td>
         <td>{{ t.coach.first_name }} {{ t.coach.last_name }}</td>
+        <td>{{ t.coach.phone_number }}</td>
+        {% set b1 = t.bookings[0].volunteer if t.bookings|length > 0 else None %}
+        {% set b2 = t.bookings[1].volunteer if t.bookings|length > 1 else None %}
+        <td>
+          {% if b1 %}{{ b1.first_name }} {{ b1.last_name }}<br><small>{{ b1.phone_number }}</small>{% endif %}
+        </td>
+        <td>
+          {% if b2 %}{{ b2.first_name }} {{ b2.last_name }}<br><small>{{ b2.phone_number }}</small>{% endif %}
+        </td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
+  {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- filter admin view to show only future trainings
- group trainings by month
- display coach contact and volunteers in training table

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from app import create_app
app = create_app()
print('app created')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68728eedd548832a8c7ed5814aa6fefb