### PR TITLE
Apply DB migrations automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Optional variables include `FLASK_ENV` and `FLASK_APP`.
    python run.py
    ```
    The application will be available on `http://localhost:8000`.
+   When started this way, the app automatically applies any pending
+   database migrations before launching.
 
 ### Database migrations
 
@@ -64,6 +66,9 @@ Alternatively, build and run with Docker:
 docker build -t treningi .
 docker run --env-file .env -p 8000:8000 treningi
 ```
+
+The container runs `python run.py`, so any pending migrations are upgraded
+automatically when it starts.
 
 You can also use `docker-compose up` which uses the provided `docker-compose.yml`.
 

--- a/run.py
+++ b/run.py
@@ -1,6 +1,9 @@
 from app import create_app
+from flask_migrate import upgrade
 
 app = create_app()
 
 if __name__ == "__main__":
+    with app.app_context():
+        upgrade()
     app.run(host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- run pending migrations on app startup
- document automatic migration in README

## Testing
- `python -m py_compile run.py app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6872a0b0de30832aa7a2be348eea254d