### PR TITLE
Add flake8 config for migrations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+per-file-ignores =
+    migrations/*:E122,E128,W291


### PR DESCRIPTION
## Summary
- add `.flake8` config that ignores style errors in migration scripts

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6872a630b2d4832ab48bd5b7eeed66f9