### PR TITLE
Check alembic table before upgrading

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,9 +1,13 @@
-from app import create_app
-from flask_migrate import upgrade
+from app import create_app, db
+from flask_migrate import upgrade, stamp
+from sqlalchemy import inspect
 
 app = create_app()
 
 if __name__ == "__main__":
     with app.app_context():
+        inspector = inspect(db.engine)
+        if "alembic_version" not in inspector.get_table_names():
+            stamp()  # mark current state
         upgrade()
     app.run(host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- ensure alembic migrations are stamped if the `alembic_version` table is missing

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6872a817f758832ab724352bd6eecd5e