### PR TITLE
Fix Dockerfile command to run app via Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . /app
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-CMD ["flask", "run", "--host=0.0.0.0", "--port=8000"]
+CMD ["python", "run.py"]


### PR DESCRIPTION
## Summary
- update Dockerfile to run the application using `python run.py`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872acefd980832ab75938d65a460986