### PR TITLE
Fix SQLite path

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -17,10 +17,12 @@ def create_app():
     # resources are available when running via ``python run.py`` as well as
     # inside Docker containers.
     app = Flask(__name__, static_folder="../static")
+    os.makedirs(app.instance_path, exist_ok=True)
+    db_file = os.path.join(app.instance_path, "db.sqlite3")
     app.config['SECRET_KEY'] = os.environ.get(
         "SECRET_KEY", "default-dev-secret"
     )
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///instance/db.sqlite3'
+    app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{db_file}"
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['ADMIN_PASSWORD'] = os.environ.get("ADMIN_PASSWORD")
 


### PR DESCRIPTION
## Summary
- ensure the instance folder exists when the Flask app starts
- build the full SQLite path from `app.instance_path`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c90ed320832a83a10808daf739ff