### PR TITLE
Use explicit migrations path

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,7 +27,10 @@ def create_app():
     app.config['ADMIN_PASSWORD'] = os.environ.get("ADMIN_PASSWORD")
 
     db.init_app(app)
-    migrate.init_app(app, db)
+    migrate_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "migrations"
+    )
+    migrate.init_app(app, db, directory=migrate_dir)
     csrf.init_app(app)
 
     with app.app_context():


### PR DESCRIPTION
## Summary
- ensure Flask-Migrate points at the root `migrations` folder

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6872c9e7cb98832a8894ed018d26c627