### PR TITLE
Use DateTimeLocalField

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -2,10 +2,10 @@ from flask_wtf import FlaskForm
 from wtforms import (
     StringField,
     SubmitField,
-    DateTimeField,
     SelectField,
     PasswordField,
 )
+from wtforms.fields.datetime import DateTimeLocalField
 from flask_wtf.file import FileField
 from wtforms.validators import DataRequired, Length
 from wtforms.fields import HiddenField
@@ -25,10 +25,11 @@ class CoachForm(FlaskForm):
 
 
 class TrainingForm(FlaskForm):
-    date = DateTimeField(
+    date = DateTimeLocalField(
         'Data i godzina treningu',
-        format='%Y-%m-%d %H:%M',
+        format='%Y-%m-%dT%H:%M',
         validators=[DataRequired()],
+        render_kw={"placeholder": "dd/mm/rrrr gg:mm"},
     )
     location_id = SelectField(
         'Miejsce', coerce=int, validators=[DataRequired()]


### PR DESCRIPTION
## Summary
- update training form to use `DateTimeLocalField`
- include placeholder hint for date and time input

## Testing
- `flake8`
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6872d2efdc48832ab7f858ad51c226bd