### PR TITLE
Move volunteer form to modal

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -30,23 +30,9 @@
           </td>
           <td>
             {% if training.bookings|length < 2 %}
-              <form method="post" class="d-inline">
-                {{ form.hidden_tag() }}
-                <div class="mb-1">
-                  {{ form.first_name.label(class="form-label") }}
-                  {{ form.first_name(class="form-control") }}
-                </div>
-                <div class="mb-1">
-                  {{ form.last_name.label(class="form-label") }}
-                  {{ form.last_name(class="form-control") }}
-                </div>
-                <div class="mb-1">
-                  {{ form.phone_number.label(class="form-label") }}
-                  {{ form.phone_number(class="form-control") }}
-                </div>
-                {{ form.training_id(value=training.id) }}
-                <button type="submit" class="btn btn-sm btn-primary">Zapisz się</button>
-              </form>
+              <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
+                Zapisz się
+              </button>
             {% else %}
               <span class="text-muted">Brak miejsc</span>
             {% endif %}
@@ -55,6 +41,51 @@
         {% endfor %}
       </tbody>
     </table>
-  {% endfor %}
-</div>
-{% endblock %}
+    {% endfor %}
+  </div>
+
+  <!-- Modal for volunteer sign-up -->
+  <div class="modal fade" id="signupModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="post">
+          {{ form.hidden_tag() }}
+          <div class="modal-header">
+            <h5 class="modal-title">Zapisz się na trening</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              {{ form.first_name.label(class="form-label") }}
+              {{ form.first_name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+              {{ form.last_name.label(class="form-label") }}
+              {{ form.last_name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+              {{ form.phone_number.label(class="form-label") }}
+              {{ form.phone_number(class="form-control") }}
+            </div>
+            {{ form.training_id }}
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary">Zapisz się</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var signupModal = document.getElementById('signupModal');
+      signupModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        var trainingId = button.getAttribute('data-training-id');
+        signupModal.querySelector('input[name="training_id"]').value = trainingId;
+      });
+    });
+  </script>
+
+  {% endblock %}


### PR DESCRIPTION
## Summary
- switch volunteer sign-up to a Bootstrap modal
- keep only a button in the schedule table

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b1cc3118832a8ceb300a66a32584