### PR TITLE
Improve mobile layout

### DIFF
--- a/app/templates/admin/history.html
+++ b/app/templates/admin/history.html
@@ -2,7 +2,8 @@
 {% block admin_content %}
 <div class="container mt-4">
   <h2>Historia treningów</h2>
-  <table class="table table-bordered table-sm mt-3">
+  <div class="table-responsive mt-3">
+  <table class="table table-bordered table-sm mb-0">
     <thead class="table-light">
       <tr>
         <th>Data</th>
@@ -28,6 +29,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 
   {% if pagination.pages > 1 %}
   <nav aria-label="Paginacja">

--- a/app/templates/admin/locations.html
+++ b/app/templates/admin/locations.html
@@ -15,7 +15,8 @@
     </div>
   </form>
 
-  <table class="table table-striped">
+  <div class="table-responsive">
+  <table class="table table-striped mb-0">
     <thead><tr><th>Nazwa</th><th>Akcje</th></tr></thead>
     <tbody>
       {% for location in locations %}
@@ -28,5 +29,6 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/admin/trainers.html
+++ b/app/templates/admin/trainers.html
@@ -23,7 +23,8 @@
     </div>
   </form>
 
-  <table class="table table-striped">
+  <div class="table-responsive">
+  <table class="table table-striped mb-0">
     <thead><tr><th>Imię i nazwisko</th><th>Telefon</th><th>Akcje</th></tr></thead>
     <tbody>
       {% for coach in coaches %}
@@ -37,5 +38,6 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endblock %}

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -34,7 +34,8 @@
 
   {% for month, ts in trainings_by_month.items() %}
   <h4 class="mt-4">{{ month|replace("-", " / ") }}</h4>
-  <table class="table table-striped table-sm">
+  <div class="table-responsive">
+  <table class="table table-striped table-sm mb-0">
     <thead>
       <tr>
         <th>Data</th>
@@ -66,6 +67,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
   {% endfor %}
 </div>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,6 +10,10 @@
     .header-logo { max-height: 60px; }
     .footer-logo { max-height: 30px; }
     .footer a { text-decoration: none; }
+    @media (max-width: 575.98px) {
+      body { padding-top: 120px; }
+      .header-logo { max-height: 50px; }
+    }
   </style>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
@@ -17,7 +21,7 @@
 
   <!-- HEADER -->
   <header class="fixed-top bg-dark text-white py-2 shadow-sm">
-    <div class="container d-flex justify-content-between align-items-center">
+    <div class="container d-flex flex-column flex-sm-row justify-content-between align-items-center gap-2">
       <div class="d-flex align-items-center gap-3">
         <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo Fundacji Widzimy Inaczej" class="header-logo">
         <div>
@@ -55,6 +59,9 @@
       <img src="https://vestmedia.pl/wp-content/uploads/2024/12/Vest-Media-5.png" alt="Vest Media" class="footer-logo">
     </div>
   </footer>
+
+  <!-- Bootstrap JS for interactive components -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 
   <script>
     document.addEventListener('DOMContentLoaded', function () {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,7 +5,8 @@
 
   {% for month, trainings in trainings_by_month.items() %}
     <h4 class="mt-4">{{ month|replace("-", " / ") }}</h4>
-    <table class="table table-bordered table-sm">
+    <div class="table-responsive">
+    <table class="table table-bordered table-sm mb-0">
       <thead class="table-light">
         <tr>
           <th>Data</th>
@@ -30,23 +31,9 @@
           </td>
           <td>
             {% if training.bookings|length < 2 %}
-              <form method="post" class="d-inline">
-                {{ form.hidden_tag() }}
-                <div class="mb-1">
-                  {{ form.first_name.label(class="form-label") }}
-                  {{ form.first_name(class="form-control") }}
-                </div>
-                <div class="mb-1">
-                  {{ form.last_name.label(class="form-label") }}
-                  {{ form.last_name(class="form-control") }}
-                </div>
-                <div class="mb-1">
-                  {{ form.phone_number.label(class="form-label") }}
-                  {{ form.phone_number(class="form-control") }}
-                </div>
-                {{ form.training_id(value=training.id) }}
-                <button type="submit" class="btn btn-sm btn-primary">Zapisz się</button>
-              </form>
+              <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
+                Zapisz się
+              </button>
             {% else %}
               <span class="text-muted">Brak miejsc</span>
             {% endif %}
@@ -55,6 +42,52 @@
         {% endfor %}
       </tbody>
     </table>
-  {% endfor %}
-</div>
-{% endblock %}
+    </div>
+    {% endfor %}
+  </div>
+
+  <!-- Modal for volunteer sign-up -->
+  <div class="modal fade" id="signupModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="post">
+          {{ form.hidden_tag() }}
+          <div class="modal-header">
+            <h5 class="modal-title">Zapisz się na trening</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              {{ form.first_name.label(class="form-label") }}
+              {{ form.first_name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+              {{ form.last_name.label(class="form-label") }}
+              {{ form.last_name(class="form-control") }}
+            </div>
+            <div class="mb-3">
+              {{ form.phone_number.label(class="form-label") }}
+              {{ form.phone_number(class="form-control") }}
+            </div>
+            {{ form.training_id }}
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary">Zapisz się</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      var signupModal = document.getElementById('signupModal');
+      signupModal.addEventListener('show.bs.modal', function (event) {
+        var button = event.relatedTarget;
+        var trainingId = button.getAttribute('data-training-id');
+        signupModal.querySelector('input[name="training_id"]').value = trainingId;
+      });
+    });
+  </script>
+
+  {% endblock %}


### PR DESCRIPTION
## Summary
- add responsive header layout and mobile tweaks
- wrap tables in `.table-responsive` so they scroll on narrow screens

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872b1cc3118832a8ceb300a66a32584