### PR TITLE
Wrap coach phone numbers with tel links

### DIFF
--- a/app/templates/admin/history.html
+++ b/app/templates/admin/history.html
@@ -16,7 +16,7 @@
       <tr>
         <td>{{ t.date.strftime('%Y-%m-%d %H:%M') }}</td>
         <td>{{ t.location.name }}</td>
-        <td>{{ t.coach.first_name }} {{ t.coach.last_name }}<br><small>{{ t.coach.phone_number }}</small></td>
+        <td>{{ t.coach.first_name }} {{ t.coach.last_name }}<br><small><a href="tel:{{ t.coach.phone_number }}">{{ t.coach.phone_number }}</a></small></td>
         <td>
           <ul class="mb-0">
             {% for b in t.bookings %}

--- a/app/templates/admin/trainers.html
+++ b/app/templates/admin/trainers.html
@@ -27,13 +27,13 @@
     <thead><tr><th>Imię i nazwisko</th><th>Telefon</th><th>Akcje</th></tr></thead>
     <tbody>
       {% for coach in coaches %}
-      <tr>
-        <td>{{ coach.first_name }} {{ coach.last_name }}</td>
-        <td>{{ coach.phone_number }}</td>
-        <td>
-          <a href="{{ url_for('admin.edit_trainer', coach_id=coach.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
-        </td>
-      </tr>
+        <tr>
+          <td>{{ coach.first_name }} {{ coach.last_name }}</td>
+          <td><a href="tel:{{ coach.phone_number }}">{{ coach.phone_number }}</a></td>
+          <td>
+            <a href="{{ url_for('admin.edit_trainer', coach_id=coach.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+          </td>
+        </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -53,7 +53,7 @@
         <td>{{ t.date.strftime('%H:%M') }}</td>
         <td>{{ t.location.name }}</td>
         <td>{{ t.coach.first_name }} {{ t.coach.last_name }}</td>
-        <td>{{ t.coach.phone_number }}</td>
+        <td><a href="tel:{{ t.coach.phone_number }}">{{ t.coach.phone_number }}</a></td>
         {% set b1 = t.bookings[0].volunteer if t.bookings|length > 0 else None %}
         {% set b2 = t.bookings[1].volunteer if t.bookings|length > 1 else None %}
         <td>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,7 +19,9 @@
   <header class="fixed-top bg-dark text-white py-2 shadow-sm">
     <div class="container d-flex justify-content-between align-items-center">
       <div class="d-flex align-items-center gap-3">
-        <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo Fundacji Widzimy Inaczej" class="header-logo">
+        <a href="http://widzimyinaczej.org.pl/">
+          <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo Fundacji Widzimy Inaczej" class="header-logo">
+        </a>
         <div>
           <h5 class="mb-0">System zapisów</h5>
           <small>na treningi blind tenisa</small>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,7 +20,7 @@
         <tr>
           <td>{{ training.date.strftime('%Y-%m-%d %H:%M') }}</td>
           <td>{{ training.location.name }}</td>
-          <td>{{ training.coach.first_name }} {{ training.coach.last_name }}<br><small>{{ training.coach.phone_number }}</small></td>
+        <td>{{ training.coach.first_name }} {{ training.coach.last_name }}<br><small><a href="tel:{{ training.coach.phone_number }}">{{ training.coach.phone_number }}</a></small></td>
           <td>
             <ul class="mb-0">
               {% for booking in training.bookings %}


### PR DESCRIPTION
## Summary
- make header logo link to main website
- link coach phone numbers via `tel:` in public listing
- link coach phone numbers via `tel:` in admin history
- link coach phone numbers via `tel:` in admin trainers list
- link coach phone numbers via `tel:` in admin trainings list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6873d51fa3e8832aba58df2d22ce9675