### PR TITLE
Center signup button and admin landing redirect

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -33,6 +33,11 @@ def login_required(view):
     return wrapped
 
 
+@admin_bp.route("/")
+def admin_root():
+    """Redirect bare /admin to the trainings view."""
+    return redirect(url_for("admin.manage_trainings"))
+
 @admin_bp.route("/login", methods=["GET", "POST"])
 def login():
     form = LoginForm()
@@ -41,7 +46,7 @@ def login():
         if form.password.data == current_app.config["ADMIN_PASSWORD"]:
             session["admin_logged_in"] = True
             flash("Zalogowano jako administrator.", "success")
-            return redirect(url_for("admin.manage_trainers"))
+            return redirect(url_for("admin.manage_trainings"))
         flash("Nieprawidłowe hasło.", "danger")
 
     return render_template("admin/login.html", form=form)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -28,7 +28,11 @@
         </div>
       </div>
       <div class="d-flex align-items-center gap-2">
-        <a href="{{ url_for('admin.manage_trainers') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+        {% if request.path.startswith('/admin') %}
+          <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light btn-sm">Powrót do tabeli</a>
+        {% else %}
+          <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+        {% endif %}
         <button id="theme-toggle" type="button" class="btn btn-outline-light btn-sm" aria-label="Przełącz motyw" aria-pressed="false">🌓</button>
       </div>
     </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,18 +28,18 @@
               {% endfor %}
             </ul>
           </td>
-          <td>
-            {% if training.bookings|length < 2 %}
-              <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
-                Zapisz się
-              </button>
-            {% else %}
-              <span class="text-muted">Brak miejsc</span>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
+        <td class="text-center">
+          {% if training.bookings|length < 2 %}
+            <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
+              Zapisz się
+            </button>
+          {% else %}
+            <span class="text-muted">Brak miejsc</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
     </table>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Summary
- center the volunteer signup button in training table
- allow returning to the training table from admin pages
- redirect `/admin` and successful logins to the trainings view

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f7bc3cbc832a8ede52195dd02af5