### PR TITLE
Rework footer layout

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -33,6 +33,11 @@ def login_required(view):
     return wrapped
 
 
+@admin_bp.route("/")
+def admin_root():
+    """Redirect bare /admin to the trainings view."""
+    return redirect(url_for("admin.manage_trainings"))
+
 @admin_bp.route("/login", methods=["GET", "POST"])
 def login():
     form = LoginForm()
@@ -41,7 +46,7 @@ def login():
         if form.password.data == current_app.config["ADMIN_PASSWORD"]:
             session["admin_logged_in"] = True
             flash("Zalogowano jako administrator.", "success")
-            return redirect(url_for("admin.manage_trainers"))
+            return redirect(url_for("admin.manage_trainings"))
         flash("Nieprawidłowe hasło.", "danger")
 
     return render_template("admin/login.html", form=form)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}System zapisów – Blind Tenis{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
     body { padding-top: 100px; }
     .header-logo { max-height: 60px; }
@@ -28,7 +29,11 @@
         </div>
       </div>
       <div class="d-flex align-items-center gap-2">
-        <a href="{{ url_for('admin.manage_trainers') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+        {% if request.path.startswith('/admin') %}
+          <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light btn-sm">Powrót do tabeli</a>
+        {% else %}
+          <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+        {% endif %}
         <button id="theme-toggle" type="button" class="btn btn-outline-light btn-sm" aria-label="Przełącz motyw" aria-pressed="false">🌓</button>
       </div>
     </div>
@@ -51,11 +56,16 @@
   <!-- FOOTER -->
   <footer class="bg-light py-3 mt-auto border-top footer">
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
-      <span class="text-muted">
-        Powered by <a href="https://vestmedia.pl" target="_blank" rel="noopener noreferrer">Vest Media</a>
+      <img src="{{ url_for('static', filename='logo.png') }}" alt="Fundacja Widzimy Inaczej" class="footer-logo">
+      <div class="text-muted">
+        <i class="bi bi-envelope-fill me-1"></i>
         <a href="mailto:kontakt@vestmedia.pl">kontakt@vestmedia.pl</a>
-      </span>
-      <img src="https://vestmedia.pl/wp-content/uploads/2024/12/Vest-Media-5.png" alt="Vest Media" class="footer-logo">
+      </div>
+      <div class="text-muted">
+        Powered by:
+        <i class="bi bi-globe mx-1"></i>
+        <a href="https://vestmedia.pl" target="_blank" rel="noopener noreferrer">Vest Media</a>
+      </div>
     </div>
   </footer>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,18 +28,18 @@
               {% endfor %}
             </ul>
           </td>
-          <td>
-            {% if training.bookings|length < 2 %}
-              <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
-                Zapisz się
-              </button>
-            {% else %}
-              <span class="text-muted">Brak miejsc</span>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
+        <td class="text-center">
+          {% if training.bookings|length < 2 %}
+            <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
+              Zapisz się
+            </button>
+          {% else %}
+            <span class="text-muted">Brak miejsc</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
     </table>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Summary
- add Bootstrap icons for UI icons
- redesign footer with logo left, email center, and Powered by with website icon right

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873f7bc3cbc832a8ede52195dd02af5