### PR TITLE
Improve header and footer mobile layout

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -33,6 +33,11 @@ def login_required(view):
     return wrapped
 
 
+@admin_bp.route("/")
+def admin_root():
+    """Redirect bare /admin to the trainings view."""
+    return redirect(url_for("admin.manage_trainings"))
+
 @admin_bp.route("/login", methods=["GET", "POST"])
 def login():
     form = LoginForm()
@@ -41,7 +46,7 @@ def login():
         if form.password.data == current_app.config["ADMIN_PASSWORD"]:
             session["admin_logged_in"] = True
             flash("Zalogowano jako administrator.", "success")
-            return redirect(url_for("admin.manage_trainers"))
+            return redirect(url_for("admin.manage_trainings"))
         flash("Nieprawidłowe hasło.", "danger")
 
     return render_template("admin/login.html", form=form)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,8 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}System zapisów – Blind Tenis{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
     body { padding-top: 100px; }
+    @media (max-width: 575.98px) {
+      body { padding-top: 140px; }
+    }
     .header-logo { max-height: 60px; }
     .footer-logo { max-height: 30px; }
     .footer a { text-decoration: none; }
@@ -17,8 +21,8 @@
 
   <!-- HEADER -->
   <header class="fixed-top bg-dark text-white py-2 shadow-sm">
-    <div class="container d-flex justify-content-between align-items-center">
-      <div class="d-flex align-items-center gap-3">
+    <div class="container d-flex flex-column flex-sm-row justify-content-between align-items-center text-center text-sm-start">
+      <div class="d-flex align-items-center gap-3 flex-column flex-sm-row">
         <a href="http://widzimyinaczej.org.pl/">
           <img src="{{ url_for('static', filename='logo.png') }}" alt="Logo Fundacji Widzimy Inaczej" class="header-logo">
         </a>
@@ -27,8 +31,12 @@
           <small>na treningi blind tenisa</small>
         </div>
       </div>
-      <div class="d-flex align-items-center gap-2">
-        <a href="{{ url_for('admin.manage_trainers') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+      <div class="d-flex align-items-center gap-2 mt-2 mt-sm-0">
+        {% if request.path.startswith('/admin') %}
+          <a href="{{ url_for('routes.index') }}" class="btn btn-outline-light btn-sm">Powrót do tabeli</a>
+        {% else %}
+          <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-outline-light btn-sm">Panel administratora</a>
+        {% endif %}
         <button id="theme-toggle" type="button" class="btn btn-outline-light btn-sm" aria-label="Przełącz motyw" aria-pressed="false">🌓</button>
       </div>
     </div>
@@ -50,12 +58,17 @@
 
   <!-- FOOTER -->
   <footer class="bg-light py-3 mt-auto border-top footer">
-    <div class="container d-flex justify-content-between align-items-center flex-wrap">
-      <span class="text-muted">
-        Powered by <a href="https://vestmedia.pl" target="_blank" rel="noopener noreferrer">Vest Media</a>
+    <div class="container d-flex flex-column flex-sm-row justify-content-between align-items-center text-center gap-2">
+      <img src="{{ url_for('static', filename='logo.png') }}" alt="Fundacja Widzimy Inaczej" class="footer-logo mb-2 mb-sm-0">
+      <div class="text-muted">
+        <i class="bi bi-envelope-fill me-1"></i>
         <a href="mailto:kontakt@vestmedia.pl">kontakt@vestmedia.pl</a>
-      </span>
-      <img src="https://vestmedia.pl/wp-content/uploads/2024/12/Vest-Media-5.png" alt="Vest Media" class="footer-logo">
+      </div>
+      <div class="text-muted">
+        Powered by:
+        <i class="bi bi-globe mx-1"></i>
+        <a href="https://vestmedia.pl" target="_blank" rel="noopener noreferrer">Vest Media</a>
+      </div>
     </div>
   </footer>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,18 +28,18 @@
               {% endfor %}
             </ul>
           </td>
-          <td>
-            {% if training.bookings|length < 2 %}
-              <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
-                Zapisz się
-              </button>
-            {% else %}
-              <span class="text-muted">Brak miejsc</span>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
+        <td class="text-center">
+          {% if training.bookings|length < 2 %}
+            <button type="button" class="btn btn-sm btn-primary signup-btn" data-bs-toggle="modal" data-bs-target="#signupModal" data-training-id="{{ training.id }}">
+              Zapisz się
+            </button>
+          {% else %}
+            <span class="text-muted">Brak miejsc</span>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
     </table>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Summary
- adjust header container to stack elements on small screens
- stack footer items vertically on mobile
- add responsive padding to avoid overlapping with fixed header

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873f7bc3cbc832a8ede52195dd02af5