### PR TITLE
Improve footer layout and table consistency

### DIFF
--- a/app/templates/admin/history.html
+++ b/app/templates/admin/history.html
@@ -2,13 +2,13 @@
 {% block admin_content %}
 <div class="container mt-4">
   <h2>Historia treningów</h2>
-  <table class="table table-bordered table-sm mt-3">
+  <table class="table table-bordered table-sm mt-3 equal-width-5">
     <thead class="table-light">
       <tr>
         <th>Data</th>
         <th>Miejsce</th>
         <th>Trener</th>
-        <th>Wolontariusze</th>
+        <th class="volunteers-col">Wolontariusze</th>
       </tr>
     </thead>
     <tbody>
@@ -17,7 +17,7 @@
         <td>{{ t.date.strftime('%Y-%m-%d %H:%M') }}</td>
         <td>{{ t.location.name }}</td>
         <td>{{ t.coach.first_name }} {{ t.coach.last_name }}<br><small><a href="tel:{{ t.coach.phone_number }}">{{ t.coach.phone_number }}</a></small></td>
-        <td>
+        <td class="volunteers-col">
           <ul class="mb-0">
             {% for b in t.bookings %}
               <li>{{ b.volunteer.first_name }} {{ b.volunteer.last_name }}</li>

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -34,7 +34,7 @@
 
   {% for month, ts in trainings_by_month.items() %}
   <h4 class="mt-4">{{ month|replace("-", " / ") }}</h4>
-  <table class="table table-striped table-sm">
+  <table class="table table-striped table-sm equal-width-7">
     <thead>
       <tr>
         <th>Data</th>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,7 +7,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
-    body { padding-top: 100px; }
+    body { padding-top: 100px; padding-bottom: 100px; }
     .header-logo { max-height: 60px; }
     .footer-logo { max-height: 30px; }
     .footer a { text-decoration: none; }
@@ -54,7 +54,7 @@
   </main>
 
   <!-- FOOTER -->
-  <footer class="bg-light py-3 mt-auto border-top footer">
+  <footer class="bg-light py-3 border-top fixed-bottom footer">
     <div class="container d-flex justify-content-between align-items-center flex-wrap">
       <img src="{{ url_for('static', filename='logo.png') }}" alt="Fundacja Widzimy Inaczej" class="footer-logo">
       <div class="text-muted">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,13 +5,13 @@
 
   {% for month, trainings in trainings_by_month.items() %}
     <h4 class="mt-4">{{ month|replace("-", " / ") }}</h4>
-    <table class="table table-bordered table-sm">
+    <table class="table table-bordered table-sm equal-width-5">
       <thead class="table-light">
         <tr>
           <th>Data</th>
           <th>Miejsce</th>
           <th>Trener</th>
-          <th>Wolontariusze</th>
+          <th class="volunteers-col">Wolontariusze</th>
           <th>Akcja</th>
         </tr>
       </thead>
@@ -21,7 +21,7 @@
           <td>{{ training.date.strftime('%Y-%m-%d %H:%M') }}</td>
           <td>{{ training.location.name }}</td>
         <td>{{ training.coach.first_name }} {{ training.coach.last_name }}<br><small><a href="tel:{{ training.coach.phone_number }}">{{ training.coach.phone_number }}</a></small></td>
-          <td>
+          <td class="volunteers-col">
             <ul class="mb-0">
               {% for booking in training.bookings %}
                 <li>{{ booking.volunteer.first_name }} {{ booking.volunteer.last_name }}</li>

--- a/static/style.css
+++ b/static/style.css
@@ -52,6 +52,26 @@ table a {
   text-decoration: underline;
 }
 
+.volunteers-col {
+  min-width: 8rem;
+}
+
+.equal-width-5,
+.equal-width-7 {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.equal-width-5 th,
+.equal-width-5 td {
+  width: 20%;
+}
+
+.equal-width-7 th,
+.equal-width-7 td {
+  width: calc(100% / 7);
+}
+
 input, select, textarea {
   border-radius: 4px;
 }
@@ -59,6 +79,7 @@ input, select, textarea {
 @media (max-width: 575.98px) {
   body {
     padding-top: 120px;
+    padding-bottom: 120px;
   }
 
   header .container {


### PR DESCRIPTION
## Summary
- pin the site footer to the bottom of the page
- offset page content to avoid footer overlap on all screen sizes
- ensure the "Wolontariusze" column keeps a constant width
- add CSS helpers so tables in each view keep matching column widths

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e2c98cc4832abb9f78fbd9617346