### PR TITLE
Switch to volunteer email addresses

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -198,9 +198,9 @@ def export_excel():
         "Trener",
         "Telefon trenera",
         "Wolontariusz 1",
-        "Telefon 1",
+        "Email 1",
         "Wolontariusz 2",
-        "Telefon 2",
+        "Email 2",
     ])
 
     trainings = Training.query.order_by(Training.date).all()
@@ -217,9 +217,9 @@ def export_excel():
             f"{t.coach.first_name} {t.coach.last_name}",
             t.coach.phone_number,
             f"{v1.first_name} {v1.last_name}" if v1 else "",
-            v1.phone_number if v1 else "",
+            v1.email if v1 else "",
             f"{v2.first_name} {v2.last_name}" if v2 else "",
-            v2.phone_number if v2 else "",
+            v2.email if v2 else "",
         ])
 
     output = BytesIO()

--- a/app/forms.py
+++ b/app/forms.py
@@ -7,7 +7,7 @@ from wtforms import (
 )
 from wtforms.fields.datetime import DateTimeLocalField
 from flask_wtf.file import FileField
-from wtforms.validators import DataRequired, Length
+from wtforms.validators import DataRequired, Length, Email
 from wtforms.fields import HiddenField, TelField
 
 
@@ -47,8 +47,8 @@ class VolunteerForm(FlaskForm):
     last_name = StringField(
         'Nazwisko', validators=[DataRequired(), Length(max=64)]
     )
-    phone_number = TelField(
-        'Telefon', validators=[DataRequired(), Length(max=20)]
+    email = StringField(
+        'Email', validators=[DataRequired(), Email(), Length(max=128)]
     )
     training_id = HiddenField()  # ukryte pole – ID treningu
     submit = SubmitField('Zapisz się')

--- a/app/routes.py
+++ b/app/routes.py
@@ -26,14 +26,14 @@ def index():
         existing_volunteer = Volunteer.query.filter_by(
             first_name=form.first_name.data.strip(),
             last_name=form.last_name.data.strip(),
-            phone_number=form.phone_number.data.strip()
+            email=form.email.data.strip(),
         ).first()
 
         if not existing_volunteer:
             existing_volunteer = Volunteer(
                 first_name=form.first_name.data.strip(),
                 last_name=form.last_name.data.strip(),
-                phone_number=form.phone_number.data.strip()
+                email=form.email.data.strip(),
             )
             db.session.add(existing_volunteer)
             db.session.commit()

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -57,10 +57,10 @@
         {% set b1 = t.bookings[0].volunteer if t.bookings|length > 0 else None %}
         {% set b2 = t.bookings[1].volunteer if t.bookings|length > 1 else None %}
         <td>
-          {% if b1 %}{{ b1.first_name }} {{ b1.last_name }}<br><small>{{ b1.phone_number }}</small>{% endif %}
+          {% if b1 %}{{ b1.first_name }} {{ b1.last_name }}<br><small>{{ b1.email }}</small>{% endif %}
         </td>
         <td>
-          {% if b2 %}{{ b2.first_name }} {{ b2.last_name }}<br><small>{{ b2.phone_number }}</small>{% endif %}
+          {% if b2 %}{{ b2.first_name }} {{ b2.last_name }}<br><small>{{ b2.email }}</small>{% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -64,8 +64,8 @@
               {{ form.last_name(class="form-control") }}
             </div>
             <div class="mb-3">
-              {{ form.phone_number.label(class="form-label") }}
-              {{ form.phone_number(class="form-control") }}
+              {{ form.email.label(class="form-label") }}
+              {{ form.email(class="form-control") }}
             </div>
             {{ form.training_id }}
           </div>


### PR DESCRIPTION
## Summary
- update `VolunteerForm` to collect an email address instead of a phone number
- adjust sign‑up route and template for the new field
- show volunteer emails in the admin training table and in Excel export

## Testing
- `flake8`
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_687693f6d334832a85630035bb1241c3