### PR TITLE
Add training cancellation endpoint

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -69,3 +69,13 @@ class LocationForm(FlaskForm):
 
     name = StringField('Nazwa', validators=[DataRequired(), Length(max=128)])
     submit = SubmitField('Zapisz')
+
+
+class CancelForm(FlaskForm):
+    """Simple form for cancelling a volunteer booking."""
+
+    email = StringField(
+        'Email', validators=[DataRequired(), Email(), Length(max=128)]
+    )
+    training_id = HiddenField()
+    submit = SubmitField('Wypisz się')

--- a/app/templates/cancel.html
+++ b/app/templates/cancel.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-4" style="max-width: 500px;">
+  <h2 class="mb-3">Wypisz się z treningu</h2>
+  {% if training %}
+    <p>
+      {{ training.date.strftime('%Y-%m-%d %H:%M') }},
+      {{ training.location.name }},
+      {{ training.coach.first_name }} {{ training.coach.last_name }}
+    </p>
+  {% endif %}
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    {{ form.training_id }}
+    <div class="mb-3">
+      {{ form.email.label(class="form-label") }}
+      {{ form.email(class="form-control") }}
+    </div>
+    <button type="submit" class="btn btn-danger">Wypisz się</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,6 +36,9 @@
           {% else %}
             <span class="text-muted">Brak miejsc</span>
           {% endif %}
+          <div class="mt-1">
+            <a href="{{ url_for('routes.cancel_booking', training_id=training.id) }}" class="btn btn-sm btn-outline-danger">Wypisz się</a>
+          </div>
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- add `CancelForm` for cancelling bookings
- link "Wypisz się" button on the main page to a new cancel view
- implement `/cancel` route that deletes an existing booking
- create `cancel.html` template

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6876b6c0ec2c832a914fe46ad7ce7119