### PR TITLE
Display volunteer emails in admin tables

### DIFF
--- a/app/templates/admin/history.html
+++ b/app/templates/admin/history.html
@@ -8,7 +8,7 @@
         <th>Data</th>
         <th>Miejsce</th>
         <th>Trener</th>
-        <th class="volunteers-col">Wolontariusze</th>
+        <th class="volunteers-col">Wolontariusze (Email)</th>
       </tr>
     </thead>
     <tbody>
@@ -20,7 +20,7 @@
         <td class="volunteers-col">
           <ul class="mb-0">
             {% for b in t.bookings %}
-              <li>{{ b.volunteer.first_name }} {{ b.volunteer.last_name }}</li>
+              <li>{{ b.volunteer.first_name }} {{ b.volunteer.last_name }} <small class="text-muted">({{ b.volunteer.email }})</small></li>
             {% endfor %}
           </ul>
         </td>

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -42,8 +42,8 @@
         <th>Miejsce</th>
         <th>Trener</th>
         <th>Telefon trenera</th>
-        <th>Wolontariusz 1</th>
-        <th>Wolontariusz 2</th>
+        <th>Wolontariusz 1 (Email)</th>
+        <th>Wolontariusz 2 (Email)</th>
       </tr>
     </thead>
     <tbody>
@@ -57,10 +57,10 @@
         {% set b1 = t.bookings[0].volunteer if t.bookings|length > 0 else None %}
         {% set b2 = t.bookings[1].volunteer if t.bookings|length > 1 else None %}
         <td>
-          {% if b1 %}{{ b1.first_name }} {{ b1.last_name }}<br><small>{{ b1.email }}</small>{% endif %}
+          {% if b1 %}{{ b1.first_name }} {{ b1.last_name }} <small class="text-muted">({{ b1.email }})</small>{% endif %}
         </td>
         <td>
-          {% if b2 %}{{ b2.first_name }} {{ b2.last_name }}<br><small>{{ b2.email }}</small>{% endif %}
+          {% if b2 %}{{ b2.first_name }} {{ b2.last_name }} <small class="text-muted">({{ b2.email }})</small>{% endif %}
         </td>
       </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- show volunteer email next to the name in admin trainings and history views
- update volunteer column headers

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6876bc71258c832ab031fe35bbcb5bc9