### PR TITLE
Add sign-up email with cancel link

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -363,7 +363,9 @@ def settings():
     form = SettingsForm(obj=settings)
 
     if form.validate_on_submit():
-        settings.server = form.server.data.strip() if form.server.data else None
+        settings.server = (
+            form.server.data.strip() if form.server.data else None
+        )
         settings.port = form.port.data
         settings.login = form.login.data.strip() if form.login.data else None
         settings.password = form.password.data if form.password.data else None

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -7,11 +7,31 @@ from email.message import EmailMessage
 def send_email(subject: str, body: str, recipients: list[str]) -> None:
     """Send a plain text email using stored SMTP settings."""
     settings = EmailSettings.query.get(1)
-    host = settings.server if settings and settings.server else current_app.config.get("SMTP_HOST")
-    username = settings.login if settings and settings.login else current_app.config.get("SMTP_USERNAME")
-    password = settings.password if settings and settings.password else current_app.config.get("SMTP_PASSWORD")
-    sender = settings.sender if settings and settings.sender else current_app.config.get("SMTP_SENDER")
-    port = settings.port if settings and settings.port else current_app.config.get("SMTP_PORT", 587)
+    host = (
+        settings.server
+        if settings and settings.server
+        else current_app.config.get("SMTP_HOST")
+    )
+    username = (
+        settings.login
+        if settings and settings.login
+        else current_app.config.get("SMTP_USERNAME")
+    )
+    password = (
+        settings.password
+        if settings and settings.password
+        else current_app.config.get("SMTP_PASSWORD")
+    )
+    sender = (
+        settings.sender
+        if settings and settings.sender
+        else current_app.config.get("SMTP_SENDER")
+    )
+    port = (
+        settings.port
+        if settings and settings.port
+        else current_app.config.get("SMTP_PORT", 587)
+    )
     use_tls = current_app.config.get("SMTP_USE_TLS", True)
 
     if not host:

--- a/app/models.py
+++ b/app/models.py
@@ -126,4 +126,3 @@ class EmailSettings(db.Model):
     sender = db.Column(db.String(128), nullable=True)
     registration_template = db.Column(db.Text, nullable=True)
     cancellation_template = db.Column(db.Text, nullable=True)
-

--- a/app/routes.py
+++ b/app/routes.py
@@ -49,9 +49,21 @@ def index():
 
         settings = EmailSettings.query.get(1)
         if settings and settings.registration_template:
-            body = settings.registration_template.format(
-                date=training.date.strftime('%Y-%m-%d %H:%M'),
-                location=training.location.name,
+            cancel_link = url_for(
+                "routes.cancel_booking",
+                training_id=training.id,
+                _external=True,
+            )
+            training_info = (
+                f"{training.date.strftime('%Y-%m-%d %H:%M')} "
+                f"w {training.location.name}"
+            )
+            body = (
+                settings.registration_template
+                .replace("[imie]", existing_volunteer.first_name)
+                .replace("[nazwisko]", existing_volunteer.last_name)
+                .replace("[trening]", training_info)
+                .replace("[link_do_odwolania]", cancel_link)
             )
             send_email(
                 "Potwierdzenie zgłoszenia",

--- a/migrations/versions/7f08637fefa3_add_is_canceled_flag.py
+++ b/migrations/versions/7f08637fefa3_add_is_canceled_flag.py
@@ -28,6 +28,5 @@ def upgrade():
     )
 
 
-
 def downgrade():
     op.drop_column('trainings', 'is_canceled')


### PR DESCRIPTION
## Summary
- notify volunteers via email after sign-up
- include `[imie]`, `[nazwisko]`, `[trening]` and `[link_do_odwolania]` placeholders
- clean up flake8 issues

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6876ca97e904832a81733f1248a2f64d