### PR TITLE
Prevent duplicate bookings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -40,6 +40,15 @@ def index():
             db.session.add(existing_volunteer)
             db.session.commit()
 
+        existing_booking = Booking.query.filter_by(
+            training_id=training.id,
+            volunteer_id=existing_volunteer.id,
+        ).first()
+
+        if existing_booking:
+            flash("Jesteś już zapisany na ten trening.", "warning")
+            return redirect(url_for("routes.index"))
+
         booking = Booking(
             training_id=training.id,
             volunteer_id=existing_volunteer.id,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,61 @@
+import pytest
+from datetime import datetime
+
+from app import create_app, db
+from app.models import Coach, Location, Training, Volunteer, Booking
+
+@pytest.fixture
+def app_instance():
+    app = create_app()
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        WTF_CSRF_ENABLED=False,
+    )
+    with app.app_context():
+        db.create_all()
+    yield app
+    with app.app_context():
+        db.drop_all()
+
+@pytest.fixture
+def client(app_instance):
+    return app_instance.test_client()
+
+
+def setup_training(app):
+    with app.app_context():
+        coach = Coach(first_name='John', last_name='Doe', phone_number='123')
+        location = Location(name='Court')
+        training = Training(date=datetime.utcnow(), coach=coach, location=location)
+        volunteer = Volunteer(first_name='Ann', last_name='Smith', email='ann@example.com')
+        db.session.add_all([coach, location, training, volunteer])
+        db.session.commit()
+        return training.id, volunteer.id, volunteer
+
+
+def test_duplicate_booking_flash(client, app_instance):
+    training_id, volunteer_id, volunteer = setup_training(app_instance)
+
+    with app_instance.app_context():
+        booking = Booking(training_id=training_id, volunteer_id=volunteer_id)
+        db.session.add(booking)
+        db.session.commit()
+
+    response = client.post(
+        '/',
+        data={
+            'first_name': volunteer.first_name,
+            'last_name': volunteer.last_name,
+            'email': volunteer.email,
+            'training_id': str(training_id),
+        },
+        follow_redirects=True,
+    )
+
+    assert b'Jeste\xc5\x9b ju\xc5\xbc zapisany na ten trening.' in response.data
+    with app_instance.app_context():
+        assert Booking.query.count() == 1
+
+
+


### PR DESCRIPTION
## Summary
- guard against creating duplicate bookings in `index`
- test that duplicate registrations show a warning

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest email_validator`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cc49dad8832a9daba81669d4be6e