### PR TITLE
Simplify Quill toolbar

### DIFF
--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -4,7 +4,16 @@ window.addEventListener('DOMContentLoaded', () => {
   function init(fieldId, editorId) {
     const field = document.getElementById(fieldId);
     if (!field) return;
-    const quill = new Quill('#' + editorId, { theme: 'snow' });
+    const quill = new Quill('#' + editorId, {
+      theme: 'snow',
+      modules: {
+        toolbar: [
+          ['bold', 'italic', 'underline'],
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          ['link']
+        ]
+      }
+    });
     quill.root.innerHTML = field.value || '';
     editors[editorId] = quill;
     field.closest('form').addEventListener('submit', () => {


### PR DESCRIPTION
## Summary
- simplify Quill toolbar used for editing email templates

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68778fc9575c832a8c62b52dd50a35ae