### PR TITLE
Add extra_head block for custom head content

### DIFF
--- a/app/templates/admin/admin_base.html
+++ b/app/templates/admin/admin_base.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
+{% block extra_head %}
 <link href="{{ url_for('static', filename='vendor/quill/quill.snow.css') }}" rel="stylesheet">
+{% endblock %}
 
 {% block content %}
 {% if session.get('admin_logged_in') %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,7 @@
     .footer a { text-decoration: none; }
   </style>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  {% block extra_head %}{% endblock %}
 </head>
 <body class="d-flex flex-column min-vh-100">
 


### PR DESCRIPTION
## Summary
- expose a new `extra_head` block in `base.html`
- place Quill stylesheet inside `extra_head` in `admin_base.html`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687795325a78832a9239a5ce7ead044c