### PR TITLE
Update Quill editors styling

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -31,7 +31,7 @@
     <div class="mb-3 mt-2">
       {{ form.registration_template.label(class="form-label") }}
       {{ form.registration_template(id="registration_template") }}
-      <div id="registration_editor" class="form-control" style="height:200px;"></div>
+      <div id="registration_editor" class="quill-wrapper" style="height:200px;"></div>
       <div class="mt-2">
         {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}'] %}
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="registration_editor" data-value="{{ var }}">{{ var }}</button>
@@ -42,7 +42,7 @@
     <div class="mb-3">
       {{ form.cancellation_template.label(class="form-label") }}
       {{ form.cancellation_template(id="cancellation_template") }}
-      <div id="cancellation_editor" class="form-control" style="height:200px;"></div>
+      <div id="cancellation_editor" class="quill-wrapper" style="height:200px;"></div>
       <div class="mt-2">
         {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}'] %}
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="cancellation_editor" data-value="{{ var }}">{{ var }}</button>

--- a/static/style.css
+++ b/static/style.css
@@ -29,7 +29,8 @@ body.dark-mode a {
 body.dark-mode .table,
 body.dark-mode .form-control,
 body.dark-mode .form-select,
-body.dark-mode .btn {
+body.dark-mode .btn,
+body.dark-mode .quill-wrapper {
   background-color: #2a2a40;
   color: var(--text-color-dark);
 }
@@ -75,6 +76,11 @@ table a {
 
 input, select, textarea {
   border-radius: 4px;
+}
+
+.quill-wrapper {
+  border: 1px solid #ced4da;
+  border-radius: .25rem;
 }
 
 @media (max-width: 575.98px) {


### PR DESCRIPTION
## Summary
- remove `form-control` from Quill editor divs
- style Quill editor wrappers with new `.quill-wrapper` rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779fc75dc4832aa581a60abaf33659