### PR TITLE
Add live preview for email templates

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -36,7 +36,7 @@
         {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}'] %}
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="registration_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
-        <a href="{{ url_for('admin.preview_template', template='registration') }}" target="_blank" class="btn btn-sm btn-outline-primary ms-2">Podgląd</a>
+        <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="registration" data-editor="registration_editor">Podgląd</button>
       </div>
     </div>
     <div class="mb-3">
@@ -47,7 +47,7 @@
         {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}'] %}
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="cancellation_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
-        <a href="{{ url_for('admin.preview_template', template='cancellation') }}" target="_blank" class="btn btn-sm btn-outline-primary ms-2">Podgląd</a>
+        <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="cancellation" data-editor="cancellation_editor">Podgląd</button>
       </div>
     </div>
     <button class="btn btn-primary">Zapisz</button>

--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -35,4 +35,25 @@ window.addEventListener('DOMContentLoaded', () => {
       editor.setSelection(index + val.length);
     });
   });
+
+  document.querySelectorAll('.preview-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const editor = editors[btn.dataset.editor];
+      if (!editor) return;
+      const content = editor.root.innerHTML;
+      fetch(`/admin/settings/preview/${btn.dataset.template}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({ content })
+      })
+        .then(resp => resp.text())
+        .then(html => {
+          const w = window.open('', '_blank');
+          if (w) {
+            w.document.write(html);
+            w.document.close();
+          }
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow POST to preview email templates with current content
- add JS helper for preview buttons
- hook preview buttons up in email settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aaf3e018832ab80c106b299d08b8