### PR TITLE
Add POST preview test and docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ The admin dashboard is accessible at `/admin/login`. Sign in using the password 
 
 ### Editing email templates
 
-Visit `/admin/settings` to configure SMTP details and edit the messages sent to volunteers. The WYSIWYG editor lets you insert variables such as `{first_name}`, `{last_name}`, `{training}`, `{cancel_link}`, `{date}` and `{location}`. Use the **Podgląd** button to preview a template with example data before saving.
+Visit `/admin/settings` to configure SMTP details and edit the messages sent to volunteers. The WYSIWYG editor lets you insert variables such as `{first_name}`, `{last_name}`, `{training}`, `{cancel_link}`, `{date}` and `{location}`. Use the **Podgląd** button to preview a template with example data before saving. Clicking the button posts the current editor content to `/admin/settings/preview/<template>` so you can check the result without modifying the stored template.
 

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -60,3 +60,17 @@ def test_preview_endpoint_renders(client, app_instance):
     resp = client.get('/admin/settings/preview/registration')
     assert resp.status_code == 200
     assert b'Hi Jan' in resp.data
+
+
+def test_preview_endpoint_allows_posting_html(client, app_instance):
+    """Posting custom HTML should be rendered without saving it."""
+    with client.session_transaction() as sess:
+        sess['admin_logged_in'] = True
+    with app_instance.app_context():
+        settings = EmailSettings(id=1, port=587, sender='a@b.com')
+        db.session.add(settings)
+        db.session.commit()
+    html = '<p>Custom Preview</p>'
+    resp = client.post('/admin/settings/preview/registration', data={'content': html})
+    assert resp.status_code == 200
+    assert b'Custom Preview' in resp.data


### PR DESCRIPTION
## Summary
- extend README with instructions for previewing unsaved email templates
- test preview endpoint with posted HTML

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877aec451cc832a8fbe8c1d484e6b4a