### PR TITLE
Fix duplicated hidden inputs

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -3,7 +3,7 @@
 <div class="container mt-4">
   <h2>Ustawienia e-mail</h2>
   <form method="POST">
-    {{ form.hidden_tag() }}
+    {{ form.csrf_token }}
     <div class="row g-2">
       <div class="col-md-4">
         {{ form.server.label(class="form-label") }}

--- a/app/templates/cancel.html
+++ b/app/templates/cancel.html
@@ -10,7 +10,7 @@
     </p>
   {% endif %}
   <form method="POST">
-    {{ form.hidden_tag() }}
+    {{ form.csrf_token }}
     {{ form.training_id }}
     <div class="mb-3">
       {{ form.email.label(class="form-label") }}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -54,7 +54,7 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <form method="post">
-          {{ form.hidden_tag() }}
+          {{ form.csrf_token }}
           <div class="modal-header">
             <h5 class="modal-title">Zapisz się na trening</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>

--- a/tests/test_hidden_fields.py
+++ b/tests/test_hidden_fields.py
@@ -1,0 +1,22 @@
+import re
+
+def test_index_has_single_training_id_field(client, app_instance, sample_data):
+    resp = client.get('/')
+    html = resp.data.decode()
+    assert len(re.findall(r'id="training_id"', html)) == 1
+
+
+def test_cancel_has_single_training_id_field(client, app_instance, sample_data):
+    training_id, _, _, _ = sample_data
+    resp = client.get(f'/cancel?training_id={training_id}')
+    html = resp.data.decode()
+    assert len(re.findall(r'id="training_id"', html)) == 1
+
+
+def test_settings_has_single_template_fields(client, app_instance):
+    with client.session_transaction() as sess:
+        sess['admin_logged_in'] = True
+    resp = client.get('/admin/settings')
+    html = resp.data.decode()
+    assert len(re.findall(r'id="registration_template"', html)) == 1
+    assert len(re.findall(r'id="cancellation_template"', html)) == 1


### PR DESCRIPTION
## Summary
- avoid rendering extra hidden fields by using `form.csrf_token`
- add regression tests to ensure only one hidden input per id

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d13db408832a9850003979ed8ef9