### PR TITLE
Add preview modal and JS functionality

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -54,7 +54,16 @@
         <button type="button" class="btn btn-sm btn-outline-secondary ms-2 html-toggle" data-editor="cancellation_editor">Edit HTML</button>
       </div>
     </div>
-    <button class="btn btn-primary">Zapisz</button>
+  <button class="btn btn-primary">Zapisz</button>
   </form>
+</div>
+
+<!-- Preview Modal -->
+<div class="modal fade" id="previewModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-body"></div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -88,11 +88,10 @@ window.addEventListener('DOMContentLoaded', () => {
       })
         .then(resp => resp.text())
         .then(html => {
-          const w = window.open('', '_blank');
-          if (w) {
-            w.document.write(html);
-            w.document.close();
-          }
+          const modal = document.getElementById('previewModal');
+          if (!modal) return;
+          modal.querySelector('.modal-body').innerHTML = html;
+          new bootstrap.Modal(modal).show();
         });
     });
   });

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -89,3 +89,18 @@ def test_preview_endpoint_allows_posting_specific_html(client, app_instance):
     resp = client.post('/admin/settings/preview/registration', data={'content': html})
     assert resp.status_code == 200
     assert b'<p>X</p>' in resp.data
+
+
+def test_preview_endpoint_returns_modal_html(client, app_instance):
+    with client.session_transaction() as sess:
+        sess['admin_logged_in'] = True
+    with app_instance.app_context():
+        settings = EmailSettings(id=1, port=587, sender='a@b.com')
+        db.session.add(settings)
+        db.session.commit()
+
+    html = '<p>Modal Test</p>'
+    resp = client.post('/admin/settings/preview/registration', data={'content': html})
+    assert resp.status_code == 200
+    assert b'<div class="border p-3">' in resp.data
+    assert b'Modal Test' in resp.data


### PR DESCRIPTION
## Summary
- add preview modal to settings template
- fetch preview HTML and show in modal instead of new window
- test POSTing preview HTML returns modal page

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877fa0640e0832a96c09973d18aa833