### PR TITLE
Add test for SMTP flash messages

### DIFF
--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -18,7 +18,7 @@ def test_admin_settings_update(client, app_instance):
     }
 
     resp = client.post('/admin/settings', data=form_data, follow_redirects=True)
-    assert b'Zapisano ustawienia' in resp.data
+    assert b'Zapisano ustawienia.' in resp.data
 
     with app_instance.app_context():
         settings = EmailSettings.query.get(1)
@@ -59,3 +59,4 @@ def test_admin_send_test_email(client, app_instance, monkeypatch):
     resp = client.post('/admin/settings/test-email', data=form_data, follow_redirects=True)
     assert resp.status_code == 200
     assert captured['args'][2] == ['dest@example.com']
+    assert b'Wys\xc5\x82ano wiadomo\xc5\x9b\xc4\x87 testow\xc4\x85.' in resp.data


### PR DESCRIPTION
## Summary
- verify flash message after saving SMTP settings
- verify flash message after sending a test email

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780624c6dc832a9d2332681b8b109b