### PR TITLE
Replace deprecated query.get calls with session.get

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -222,7 +222,7 @@ def cancel_training(training_id):
     db.session.commit()
 
     subject = "Trening odwołany"
-    settings = EmailSettings.query.get(1)
+    settings = db.session.get(EmailSettings, 1)
     body_template = (
         settings.cancellation_template
         if settings and settings.cancellation_template
@@ -405,7 +405,7 @@ def history():
 @login_required
 def settings():
     """Edit email configuration."""
-    settings = EmailSettings.query.get(1)
+    settings = db.session.get(EmailSettings, 1)
     if not settings:
         settings = EmailSettings(id=1, port=587)
         db.session.add(settings)
@@ -455,7 +455,7 @@ def test_email():
 @login_required
 @csrf.exempt
 def preview_template(template):
-    settings = EmailSettings.query.get(1)
+    settings = db.session.get(EmailSettings, 1)
     if not settings:
         abort(404)
 

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1,5 +1,6 @@
 from flask import current_app
 from .models import EmailSettings
+from . import db
 import smtplib
 from email.message import EmailMessage
 import re
@@ -13,7 +14,7 @@ def send_email(
     html_body: str | None = None,
 ) -> None:
     """Send an email using stored SMTP settings."""
-    settings = EmailSettings.query.get(1)
+    settings = db.session.get(EmailSettings, 1)
     host = (
         settings.server
         if settings and settings.server

--- a/app/routes.py
+++ b/app/routes.py
@@ -57,7 +57,7 @@ def index():
         db.session.add(booking)
         db.session.commit()
 
-        settings = EmailSettings.query.get(1)
+        settings = db.session.get(EmailSettings, 1)
         if settings and settings.registration_template:
             cancel_link = url_for(
                 "routes.cancel_booking",

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -1,4 +1,5 @@
 import pytest
+from app import db
 from app.models import EmailSettings
 
 
@@ -21,7 +22,7 @@ def test_admin_settings_update(client, app_instance):
     assert b'Zapisano ustawienia.' in resp.data
 
     with app_instance.app_context():
-        settings = EmailSettings.query.get(1)
+        settings = db.session.get(EmailSettings, 1)
         assert settings.server == 'smtp.test.com'
         assert settings.port == 2525
         assert settings.login == 'user'

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -45,7 +45,7 @@ def test_deleted_training_shows_in_history(client, app_instance):
     training_id, _ = setup_training(app_instance)
 
     with app_instance.app_context():
-        training = Training.query.get(training_id)
+        training = db.session.get(Training, training_id)
         training.is_deleted = True
         db.session.commit()
 


### PR DESCRIPTION
## Summary
- replace `Model.query.get()` with `db.session.get(Model, id)`
- adjust imports in email utils and tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_687806f8c400832ab4d2501928375f95