### PR TITLE
Simplify email preview output

### DIFF
--- a/app/templates/admin/preview_email.html
+++ b/app/templates/admin/preview_email.html
@@ -1,9 +1,3 @@
-{% extends "admin/admin_base.html" %}
-{% block admin_content %}
-<div class="container mt-4">
-  <h2>Podgląd</h2>
-  <div class="border p-3">
-    {{ html|safe }}
-  </div>
+<div class="border p-3">
+  {{ html|safe }}
 </div>
-{% endblock %}

--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -87,10 +87,10 @@ window.addEventListener('DOMContentLoaded', () => {
         body: new URLSearchParams({ content })
       })
         .then(resp => resp.text())
-        .then(html => {
+        .then(snippet => {
           const modal = document.getElementById('previewModal');
           if (!modal) return;
-          modal.querySelector('.modal-body').innerHTML = html;
+          modal.querySelector('.modal-body').innerHTML = snippet;
           new bootstrap.Modal(modal).show();
         });
     });

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -104,3 +104,4 @@ def test_preview_endpoint_returns_modal_html(client, app_instance):
     assert resp.status_code == 200
     assert b'<div class="border p-3">' in resp.data
     assert b'Modal Test' in resp.data
+    assert b'<html' not in resp.data


### PR DESCRIPTION
## Summary
- strip admin layout from email preview template
- adjust email editor script to insert preview snippet
- ensure preview route test checks for absence of page wrapper

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687810810afc832aab88ac44ac097080