### PR TITLE
Replace HTML edit buttons with toggle switch

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -44,7 +44,8 @@
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="registration_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
         <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="registration" data-editor="registration_editor">Podgląd</button>
-        <button type="button" class="btn btn-sm btn-outline-secondary ms-2 html-toggle" data-editor="registration_editor">Edit HTML</button>
+        <input type="checkbox" class="form-check-input html-toggle-switch" data-editor="registration_editor" id="registration_html_switch">
+        <label class="form-check-label ms-1" for="registration_html_switch">Tryb HTML</label>
       </div>
     </div>
     <div class="mb-3">
@@ -57,7 +58,8 @@
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="cancellation_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
         <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="cancellation" data-editor="cancellation_editor">Podgląd</button>
-        <button type="button" class="btn btn-sm btn-outline-secondary ms-2 html-toggle" data-editor="cancellation_editor">Edit HTML</button>
+        <input type="checkbox" class="form-check-input html-toggle-switch" data-editor="cancellation_editor" id="cancellation_html_switch">
+        <label class="form-check-label ms-1" for="cancellation_html_switch">Tryb HTML</label>
       </div>
     </div>
   {{ form.submit(class="btn btn-primary") }}

--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -18,25 +18,26 @@ window.addEventListener('DOMContentLoaded', () => {
     editors[editorId] = quill;
 
     const textarea = document.getElementById(editorId + '_textarea');
-    const toggleBtn = document.querySelector(
-      '.html-toggle[data-editor="' + editorId + '"]'
+    const toggleSwitch = document.querySelector(
+      '.html-toggle-switch[data-editor="' + editorId + '"]'
     );
     const container = document.getElementById(editorId);
 
-    if (toggleBtn && textarea) {
-      toggleBtn.addEventListener('click', () => {
-        if (textarea.classList.contains('d-none')) {
-          textarea.value = quill.root.innerHTML;
-          textarea.classList.remove('d-none');
-          container.classList.add('d-none');
-          toggleBtn.textContent = 'Visual Editor';
-        } else {
-          quill.clipboard.dangerouslyPasteHTML(textarea.value);
-          textarea.classList.add('d-none');
-          container.classList.remove('d-none');
-          toggleBtn.textContent = 'Edit HTML';
-        }
-      });
+    function updateMode() {
+      if (toggleSwitch.checked) {
+        textarea.value = quill.root.innerHTML;
+        textarea.classList.remove('d-none');
+        container.classList.add('d-none');
+      } else {
+        quill.clipboard.dangerouslyPasteHTML(textarea.value);
+        textarea.classList.add('d-none');
+        container.classList.remove('d-none');
+      }
+    }
+
+    if (toggleSwitch && textarea) {
+      toggleSwitch.addEventListener('change', updateMode);
+      updateMode();
     }
 
     field.closest('form').addEventListener('submit', () => {

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -61,3 +61,12 @@ def test_admin_send_test_email(client, app_instance, monkeypatch):
     assert resp.status_code == 200
     assert captured['args'][2] == ['dest@example.com']
     assert b'Wys\xc5\x82ano wiadomo\xc5\x9b\xc4\x87 testow\xc4\x85.' in resp.data
+
+
+def test_settings_page_has_html_switch(client):
+    login = client.post('/admin/login', data={'password': 'secret'}, follow_redirects=True)
+    assert b'Zalogowano' in login.data
+
+    resp = client.get('/admin/settings')
+    assert b'html-toggle-switch' in resp.data
+    assert b'Tryb HTML' in resp.data


### PR DESCRIPTION
## Summary
- swap Edit HTML buttons for checkbox toggle
- update email editor JS to handle checkbox toggle
- keep correct content when submitting form
- test settings page contains new HTML switch

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687811595fd4832ab228209b31792f49