### PR TITLE
Add configurable log level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 FLASK_ENV=development
+LOG_LEVEL=INFO
 SECRET_KEY=your-secret-key
 ADMIN_PASSWORD=your-admin-password
 SMTP_HOST=smtp.example.com

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create a `.env` file and define at least:
   - `SMTP_HOST` – outgoing mail server.
   - `SMTP_USERNAME` and `SMTP_PASSWORD` – credentials for the server.
   - `SMTP_SENDER` – address used in the `From` header.
-Optional variables include `FLASK_ENV` and `FLASK_APP`.
+Optional variables include `FLASK_ENV`, `FLASK_APP` and `LOG_LEVEL`.
 
 ## Local setup
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
 from dotenv import load_dotenv
+import logging
 import os
 
 load_dotenv()
@@ -35,6 +36,14 @@ def create_app():
         "noreply@example.com",
     )
     app.config['SMTP_USE_TLS'] = os.environ.get("SMTP_USE_TLS", "1") == "1"
+
+    log_level = os.environ.get("LOG_LEVEL")
+    if log_level:
+        level_value = getattr(logging, log_level.upper(), None)
+        if isinstance(level_value, int):
+            app.logger.setLevel(level_value)
+        else:
+            app.logger.warning("Invalid LOG_LEVEL: %s", log_level)
 
     db.init_app(app)
     migrate_dir = os.path.join(


### PR DESCRIPTION
## Summary
- allow setting log level via `LOG_LEVEL` environment variable
- document the new option
- update example `.env`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781e32b9f8832aa45f9984b0031b7f