### PR TITLE
Add default log level in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Create a `.env` file and define at least:
   - `SMTP_SENDER` – address used in the `From` header.
 Optional variables include `FLASK_ENV`, `FLASK_APP` and `LOG_LEVEL`.
 `LOG_LEVEL` controls the verbosity of both the Flask logger and the
-root Python logger.
+root Python logger. If `LOG_LEVEL` is not set and the environment is
+development (`FLASK_ENV=development` or debug mode), the Flask logger
+defaults to the `INFO` level.
 
 ## Local setup
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -45,6 +45,8 @@ def create_app():
             logging.getLogger().setLevel(level_value)
         else:
             app.logger.warning("Invalid LOG_LEVEL: %s", log_level)
+    elif os.environ.get("FLASK_ENV") == "development" or app.debug:
+        app.logger.setLevel(logging.INFO)
 
     db.init_app(app)
     migrate_dir = os.path.join(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,11 @@
+import logging
+from app import create_app
+
+
+def test_default_log_level(monkeypatch):
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    monkeypatch.setenv("FLASK_ENV", "development")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
+    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    app = create_app()
+    assert app.logger.level == logging.INFO


### PR DESCRIPTION
## Summary
- set Flask logger to INFO when no LOG_LEVEL is defined in development
- document default LOG_LEVEL behaviour
- test default log level logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687838490460832a8cf0bf7d8140c5b0