### PR TITLE
Clarify log level requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ Create a `.env` file and define at least:
   - `SMTP_SENDER` – address used in the `From` header.
 Optional variables include `FLASK_ENV`, `FLASK_APP` and `LOG_LEVEL`.
 `LOG_LEVEL` controls the verbosity of both the Flask logger and the
-root Python logger. If `LOG_LEVEL` is not set and the environment is
-development (`FLASK_ENV=development` or debug mode), the Flask logger
-defaults to the `INFO` level.
+root Python logger. When not set Flask uses the `WARNING` level, which
+suppresses informational messages. In a development environment
+(`FLASK_ENV=development` or debug mode) Flask automatically switches to
+`INFO`.
+
+To see messages about sending emails and SMTP login, explicitly set
+`LOG_LEVEL=INFO` (or `DEBUG`).
 
 ## Local setup
 


### PR DESCRIPTION
## Summary
- document the default `WARNING` log level
- note that `LOG_LEVEL=INFO` or `DEBUG` is needed to see email logs

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783d4ae734832a81010949892ecaa3