### PR TITLE
Improve logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ informational messages. In a development environment
 
 To see messages about sending emails and SMTP login, explicitly set
 `LOG_LEVEL=INFO`. This enables the informational log lines describing
-email delivery.
+email delivery. When an email is sent you should see log entries like:
+
+```text
+INFO:app:Sending email via smtp.example.com:25 from Admin <noreply@example.com> to user@example.com
+INFO:app:Email sent successfully
+```
 
 ## Local setup
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,10 +3,11 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_wtf.csrf import CSRFProtect
 from dotenv import load_dotenv
+from pathlib import Path
 import logging
 import os
 
-load_dotenv()
+load_dotenv(Path(__file__).resolve().parents[1] / '.env')
 
 db = SQLAlchemy()
 migrate = Migrate()
@@ -57,9 +58,8 @@ def create_app():
         level_value = _resolve_log_level(log_level)
         if isinstance(level_value, int):
             app.logger.setLevel(level_value)
+            logging.basicConfig(level=level_value)
             app.logger.info("Logging level set to %s", log_level.upper())
-            # Ensure the root logger matches the application log level
-            logging.getLogger().setLevel(level_value)
         else:
             app.logger.warning("Invalid LOG_LEVEL value: %s", log_level)
     elif os.environ.get("FLASK_ENV") == "development" or app.debug:


### PR DESCRIPTION
## Summary
- load environment variables from project root
- configure root logger with `logging.basicConfig`
- document example log output
- ensure send_email logs at INFO level

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4f409f80832aac9e6cc9757a7421