### PR TITLE
Switch-based HTML editor toggle

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -45,7 +45,10 @@
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="registration_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
         <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="registration" data-editor="registration_editor">Podgląd</button>
-        <button type="button" class="btn btn-sm btn-outline-secondary ms-2 html-toggle" data-editor="registration_editor">Edit HTML</button>
+        <div class="form-check form-switch d-inline-block ms-2">
+          <input class="form-check-input html-toggle" type="checkbox" role="switch" id="registration_html_toggle" data-editor="registration_editor">
+          <label class="form-check-label" for="registration_html_toggle">Edytuj HTML</label>
+        </div>
       </div>
     </div>
     <div class="mb-3">
@@ -58,7 +61,10 @@
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="cancellation_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
         <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="cancellation" data-editor="cancellation_editor">Podgląd</button>
-        <button type="button" class="btn btn-sm btn-outline-secondary ms-2 html-toggle" data-editor="cancellation_editor">Edit HTML</button>
+        <div class="form-check form-switch d-inline-block ms-2">
+          <input class="form-check-input html-toggle" type="checkbox" role="switch" id="cancellation_html_toggle" data-editor="cancellation_editor">
+          <label class="form-check-label" for="cancellation_html_toggle">Edytuj HTML</label>
+        </div>
       </div>
     </div>
   {{ form.submit(class="btn btn-primary") }}

--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -18,25 +18,27 @@ window.addEventListener('DOMContentLoaded', () => {
     editors[editorId] = quill;
 
     const textarea = document.getElementById(editorId + '_textarea');
-    const toggleBtn = document.querySelector(
+    const toggleSwitch = document.querySelector(
       '.html-toggle[data-editor="' + editorId + '"]'
     );
     const container = document.getElementById(editorId);
 
-    if (toggleBtn && textarea) {
-      toggleBtn.addEventListener('click', () => {
-        if (textarea.classList.contains('d-none')) {
+    if (toggleSwitch && textarea) {
+      const update = () => {
+        if (toggleSwitch.checked) {
           textarea.value = quill.root.innerHTML;
           textarea.classList.remove('d-none');
           container.classList.add('d-none');
-          toggleBtn.textContent = 'Visual Editor';
         } else {
           quill.clipboard.dangerouslyPasteHTML(textarea.value);
           textarea.classList.add('d-none');
           container.classList.remove('d-none');
-          toggleBtn.textContent = 'Edit HTML';
         }
-      });
+      };
+      toggleSwitch.addEventListener('change', update);
+      if (toggleSwitch.checked) {
+        update();
+      }
     }
 
     field.closest('form').addEventListener('submit', () => {


### PR DESCRIPTION
## Summary
- use a Bootstrap switch instead of a button to toggle HTML edit mode
- read switch checked state in the email editor script

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a51901984832a8d1fee445c23cb85