### PR TITLE
Allow preview without saved settings

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -453,18 +453,19 @@ def test_email():
 @csrf.exempt
 def preview_template(template):
     settings = db.session.get(EmailSettings, 1)
-    if not settings:
-        abort(404)
 
     if flask.request.method == "POST" and "content" in flask.request.form:
         tpl = flask.request.form.get("content", "")
     else:
-        if template == "registration":
-            tpl = settings.registration_template or ""
-        elif template == "cancellation":
-            tpl = settings.cancellation_template or ""
-        else:
+        if template not in ("registration", "cancellation"):
             abort(404)
+        if settings:
+            if template == "registration":
+                tpl = settings.registration_template or ""
+            else:  # template == "cancellation"
+                tpl = settings.cancellation_template or ""
+        else:
+            tpl = ""
 
     data = {
         "first_name": "Jan",

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -106,3 +106,14 @@ def test_preview_endpoint_returns_modal_html(client, app_instance):
     assert b'<div class="border p-3">' in resp.data
     assert b'Modal Test' in resp.data
     assert b'<html' not in resp.data
+
+
+def test_preview_without_settings_record(client, app_instance):
+    """Preview should work when no EmailSettings exist."""
+    with client.session_transaction() as sess:
+        sess['admin_logged_in'] = True
+
+    html = '<p>No settings</p>'
+    resp = client.post('/admin/settings/preview/registration', data={'content': html})
+    assert resp.status_code == 200
+    assert b'No settings' in resp.data


### PR DESCRIPTION
## Summary
- fix preview endpoint to work before settings are saved
- test preview generation without saved settings

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a52a1d130832aaddc68bbc38a912c