### PR TITLE
Ensure all email settings persist after saving

### DIFF
--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -146,4 +146,8 @@ def test_settings_validation_passes(client, app_instance, monkeypatch):
 
     with app_instance.app_context():
         settings = db.session.get(EmailSettings, 1)
+        assert settings.server == "smtp.test.com"
+        assert settings.port == 2525
+        assert settings.login == "user"
+        assert settings.password == "pass"
         assert settings.sender == "Admin"


### PR DESCRIPTION
## Summary
- verify persistence of all email settings after form submission

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a55fb5920832aa347be1b661b8350