### PR TITLE
Improve email error handling

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -237,7 +237,9 @@ def cancel_training(training_id):
         html_body = f"Trening {data['date']} w {data['location']} został odwołany."
     recipients = [b.volunteer.email for b in training.bookings]
     if recipients:
-        send_email(subject, None, recipients, html_body=html_body)
+        success = send_email(subject, None, recipients, html_body=html_body)
+        if not success:
+            flash("Nie udało się wysłać e-maila", "danger")
 
     flash("Trening został oznaczony jako odwołany.", "warning")
     return redirect(url_for("admin.manage_trainings"))
@@ -429,7 +431,7 @@ def test_email():
     if form.validate_on_submit():
         recipient = form.test_recipient.data.strip()
         try:
-            send_email(
+            success = send_email(
                 "Test konfiguracji",
                 "To jest testowa wiadomość.",
                 [recipient],
@@ -439,7 +441,10 @@ def test_email():
                 password=form.password.data or None,
                 sender=form.sender.data or None,
             )
-            flash("Wysłano wiadomość testową.", "success")
+            if success:
+                flash("Wysłano wiadomość testową.", "success")
+            else:
+                flash("Nie udało się wysłać wiadomości testowej.", "danger")
         except Exception:  # pragma: no cover - safety net
             current_app.logger.exception("Failed to send test email")
             flash("Nie udało się wysłać wiadomości testowej.", "danger")

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -18,7 +18,7 @@ def send_email(
     password: str | None = None,
     sender: str | None = None,
     use_tls: bool | None = None,
-) -> None:
+) -> bool:
     """Send an email using stored SMTP settings."""
     settings = db.session.get(EmailSettings, 1)
     host = host or (
@@ -49,7 +49,7 @@ def send_email(
 
     if not host:
         current_app.logger.warning("SMTP_HOST not configured; skipping email")
-        return
+        return True
 
     if display_name and ("@" in display_name or "<" in display_name):
         sender_header = display_name
@@ -89,6 +89,7 @@ def send_email(
                 smtp.login(username, password)
             smtp.send_message(msg)
         current_app.logger.info("Email sent successfully")
-    except Exception:
+        return True
+    except (smtplib.SMTPException, OSError):
         current_app.logger.exception("Email sending failed")
-        raise
+        return False

--- a/app/routes.py
+++ b/app/routes.py
@@ -79,12 +79,14 @@ def index():
             html_body = render_template_string(
                 settings.registration_template, data
             )
-            send_email(
+            success = send_email(
                 "Potwierdzenie zgłoszenia",
                 None,
                 [existing_volunteer.email],
                 html_body=html_body,
             )
+            if not success:
+                flash("Nie udało się wysłać potwierdzenia", "danger")
         flash("Zapisano na trening!", "success")
         return redirect(url_for('routes.index'))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def client(app_instance):
 
 @pytest.fixture(autouse=True)
 def no_email(monkeypatch):
-    monkeypatch.setattr("app.email_utils.send_email", lambda *a, **k: None)
+    monkeypatch.setattr("app.email_utils.send_email", lambda *a, **k: True)
 
 
 @pytest.fixture

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -105,7 +105,7 @@ def test_test_email_preserves_form_data(client, monkeypatch):
         "test_recipient": "dest@example.com",
     }
 
-    monkeypatch.setattr("app.admin_routes.send_email", lambda *a, **k: None)
+    monkeypatch.setattr("app.admin_routes.send_email", lambda *a, **k: True)
 
     resp = client.post("/admin/settings/test-email", data=form_data)
     assert resp.status_code == 200

--- a/tests/test_email_failure.py
+++ b/tests/test_email_failure.py
@@ -1,0 +1,70 @@
+import smtplib
+import pytest
+from app.email_utils import send_email
+
+# override autouse fixture so send_email is not mocked
+@pytest.fixture(autouse=True)
+def no_email():
+    yield
+
+
+def test_send_email_failure_returns_false(app_instance, monkeypatch):
+    class FailingSMTP:
+        def __init__(self, host, port):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def starttls(self):
+            pass
+        def login(self, username, password):
+            pass
+        def send_message(self, msg):
+            raise smtplib.SMTPException("boom")
+
+    monkeypatch.setattr(smtplib, "SMTP", FailingSMTP)
+    with app_instance.app_context():
+        result = send_email("Sub", "Body", ["to@example.com"], host="h", port=25)
+        assert result is False
+
+
+def test_admin_flash_on_email_failure(client, app_instance, monkeypatch):
+    # login first
+    login = client.post(
+        "/admin/login", data={"password": "secret"}, follow_redirects=True
+    )
+    assert b"Zalogowano" in login.data
+
+    class FailingSMTP:
+        def __init__(self, host, port):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def starttls(self):
+            pass
+        def login(self, username, password):
+            pass
+        def send_message(self, msg):
+            raise smtplib.SMTPException("boom")
+
+    monkeypatch.setattr(smtplib, "SMTP", FailingSMTP)
+
+    form_data = {
+        "server": "smtp.test.com",
+        "port": "2525",
+        "login": "user",
+        "password": "pass",
+        "sender": "Admin",
+        "registration_template": "Hi",
+        "cancellation_template": "Bye",
+        "test_recipient": "dest@example.com",
+    }
+
+    resp = client.post(
+        "/admin/settings/test-email", data=form_data, follow_redirects=True
+    )
+    assert b"Nie uda\xc5\x82o si\xc4\x99 wys\xc5\x82a\xc4\x87 wiadomo\xc5\x9bci testowej." in resp.data
+


### PR DESCRIPTION
## Summary
- return `bool` from `send_email` and swallow SMTP errors
- show flash message when emails can't be sent from routes
- treat mocked `send_email` as success in tests
- test failures when SMTP errors occur

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a5e7dfe04832a8bf9fcefd24481d2