### PR TITLE
Expose SMTP error details in admin alerts

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -237,9 +237,12 @@ def cancel_training(training_id):
         html_body = f"Trening {data['date']} w {data['location']} został odwołany."
     recipients = [b.volunteer.email for b in training.bookings]
     if recipients:
-        success = send_email(subject, None, recipients, html_body=html_body)
+        success, error = send_email(subject, None, recipients, html_body=html_body)
         if not success:
-            flash("Nie udało się wysłać e-maila", "danger")
+            msg = "Nie udało się wysłać e-maila"
+            if error:
+                msg += f": {error}"
+            flash(msg, "danger")
 
     flash("Trening został oznaczony jako odwołany.", "warning")
     return redirect(url_for("admin.manage_trainings"))
@@ -431,7 +434,7 @@ def test_email():
     if form.validate_on_submit():
         recipient = form.test_recipient.data.strip()
         try:
-            success = send_email(
+            success, error = send_email(
                 "Test konfiguracji",
                 "To jest testowa wiadomość.",
                 [recipient],
@@ -444,7 +447,10 @@ def test_email():
             if success:
                 flash("Wysłano wiadomość testową.", "success")
             else:
-                flash("Nie udało się wysłać wiadomości testowej.", "danger")
+                msg = "Nie udało się wysłać wiadomości testowej"
+                if error:
+                    msg += f": {error}"
+                flash(msg, "danger")
         except Exception:  # pragma: no cover - safety net
             current_app.logger.exception("Failed to send test email")
             flash("Nie udało się wysłać wiadomości testowej.", "danger")

--- a/app/routes.py
+++ b/app/routes.py
@@ -79,14 +79,17 @@ def index():
             html_body = render_template_string(
                 settings.registration_template, data
             )
-            success = send_email(
+            success, error = send_email(
                 "Potwierdzenie zgłoszenia",
                 None,
                 [existing_volunteer.email],
                 html_body=html_body,
             )
             if not success:
-                flash("Nie udało się wysłać potwierdzenia", "danger")
+                msg = "Nie udało się wysłać potwierdzenia"
+                if error:
+                    msg += f": {error}"
+                flash(msg, "danger")
         flash("Zapisano na trening!", "success")
         return redirect(url_for('routes.index'))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def client(app_instance):
 
 @pytest.fixture(autouse=True)
 def no_email(monkeypatch):
-    monkeypatch.setattr("app.email_utils.send_email", lambda *a, **k: True)
+    monkeypatch.setattr("app.email_utils.send_email", lambda *a, **k: (True, None))
 
 
 @pytest.fixture

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -105,7 +105,7 @@ def test_test_email_preserves_form_data(client, monkeypatch):
         "test_recipient": "dest@example.com",
     }
 
-    monkeypatch.setattr("app.admin_routes.send_email", lambda *a, **k: True)
+    monkeypatch.setattr("app.admin_routes.send_email", lambda *a, **k: (True, None))
 
     resp = client.post("/admin/settings/test-email", data=form_data)
     assert resp.status_code == 200

--- a/tests/test_email_failure.py
+++ b/tests/test_email_failure.py
@@ -25,8 +25,9 @@ def test_send_email_failure_returns_false(app_instance, monkeypatch):
 
     monkeypatch.setattr(smtplib, "SMTP", FailingSMTP)
     with app_instance.app_context():
-        result = send_email("Sub", "Body", ["to@example.com"], host="h", port=25)
-        assert result is False
+        success, error = send_email("Sub", "Body", ["to@example.com"], host="h", port=25)
+        assert success is False
+        assert error == "boom"
 
 
 def test_admin_flash_on_email_failure(client, app_instance, monkeypatch):
@@ -66,5 +67,6 @@ def test_admin_flash_on_email_failure(client, app_instance, monkeypatch):
     resp = client.post(
         "/admin/settings/test-email", data=form_data, follow_redirects=True
     )
-    assert b"Nie uda\xc5\x82o si\xc4\x99 wys\xc5\x82a\xc4\x87 wiadomo\xc5\x9bci testowej." in resp.data
+    assert b"Nie uda\xc5\x82o si\xc4\x99 wys\xc5\x82a\xc4\x87 wiadomo\xc5\x9bci testowej" in resp.data
+    assert b"boom" in resp.data
 


### PR DESCRIPTION
## Summary
- return SMTP error details from `send_email`
- display exception messages when sending emails fails in admin UI
- adjust signup route to show failure reason
- update tests for new return value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a6e39310c832aa34a5ff11dd220cf