### PR TITLE
Add CSRF tokens to training actions

### DIFF
--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -69,10 +69,12 @@
             <span class="text-danger me-1">Odwołany</span>
           {% else %}
             <form method="post" action="{{ url_for('admin.cancel_training', training_id=t.id) }}" class="d-inline me-1">
+              {{ csrf_token() }}
               <button class="btn btn-sm btn-outline-danger">Odwołaj</button>
             </form>
           {% endif %}
           <form method="post" action="{{ url_for('admin.delete_training', training_id=t.id) }}" class="d-inline">
+            {{ csrf_token() }}
             <button class="btn btn-sm btn-outline-secondary">Usuń</button>
           </form>
         </td>


### PR DESCRIPTION
## Summary
- protect training cancellation and deletion forms with CSRF tokens

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e57121ea0832ab4fb6705560a1463