### PR TITLE
Replace training action buttons with icons

### DIFF
--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -64,18 +64,24 @@
           {% if b2 %}{{ b2.first_name }} {{ b2.last_name }} <small class="text-muted">({{ b2.email }})</small>{% endif %}
         </td>
         <td>
-          <a href="{{ url_for('admin.edit_training', training_id=t.id) }}" class="btn btn-sm btn-outline-primary me-1">Edytuj</a>
+          <a href="{{ url_for('admin.edit_training', training_id=t.id) }}" class="btn btn-sm btn-outline-primary me-1" title="Edytuj">
+            <i class="bi bi-pencil"></i>
+          </a>
           {% if t.is_canceled %}
             <span class="text-danger me-1">Odwołany</span>
           {% else %}
             <form method="post" action="{{ url_for('admin.cancel_training', training_id=t.id) }}" class="d-inline me-1">
               {{ csrf_token() }}
-              <button class="btn btn-sm btn-outline-danger">Odwołaj</button>
+              <button class="btn btn-sm btn-outline-danger" title="Odwołaj">
+                <i class="bi bi-calendar-x"></i>
+              </button>
             </form>
           {% endif %}
           <form method="post" action="{{ url_for('admin.delete_training', training_id=t.id) }}" class="d-inline">
             {{ csrf_token() }}
-            <button class="btn btn-sm btn-outline-secondary">Usuń</button>
+            <button class="btn btn-sm btn-outline-secondary" title="Usuń">
+              <i class="bi bi-trash"></i>
+            </button>
           </form>
         </td>
       </tr>


### PR DESCRIPTION
## Summary
- swap text buttons for edit/cancel/delete training with icon buttons
- add tooltips for actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4da579e4832a8b36c8616150b0a2