### PR TITLE
Fix admin action buttons

### DIFF
--- a/app/templates/admin/locations.html
+++ b/app/templates/admin/locations.html
@@ -22,7 +22,9 @@
       <tr>
         <td>{{ location.name }}</td>
         <td>
-          <a href="{{ url_for('admin.edit_location', location_id=location.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+          <a href="{{ url_for('admin.edit_location', location_id=location.id) }}" class="btn btn-sm btn-outline-primary" title="Edytuj">
+            <i class="bi bi-pencil"></i>
+          </a>
         </td>
       </tr>
       {% endfor %}

--- a/app/templates/admin/trainers.html
+++ b/app/templates/admin/trainers.html
@@ -31,7 +31,9 @@
           <td>{{ coach.first_name }} {{ coach.last_name }}</td>
           <td><a href="tel:{{ coach.phone_number }}">{{ coach.phone_number }}</a></td>
           <td>
-            <a href="{{ url_for('admin.edit_trainer', coach_id=coach.id) }}" class="btn btn-sm btn-primary">Edytuj</a>
+            <a href="{{ url_for('admin.edit_trainer', coach_id=coach.id) }}" class="btn btn-sm btn-outline-primary" title="Edytuj">
+              <i class="bi bi-pencil"></i>
+            </a>
           </td>
         </tr>
       {% endfor %}

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -71,14 +71,14 @@
             <span class="text-danger me-1">Odwołany</span>
           {% else %}
             <form method="post" action="{{ url_for('admin.cancel_training', training_id=t.id) }}" class="d-inline me-1">
-              {{ csrf_token() }}
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
               <button class="btn btn-sm btn-outline-danger" title="Odwołaj">
                 <i class="bi bi-calendar-x"></i>
               </button>
             </form>
           {% endif %}
           <form method="post" action="{{ url_for('admin.delete_training', training_id=t.id) }}" class="d-inline">
-            {{ csrf_token() }}
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button class="btn btn-sm btn-outline-secondary" title="Usuń">
               <i class="bi bi-trash"></i>
             </button>


### PR DESCRIPTION
## Summary
- hide CSRF tokens in training list action forms
- display edit links with icons in trainer and location lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fa384fcd4832aa3e1180df8330947