### PR TITLE
Remove unused TextAreaField import

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -9,7 +9,7 @@ from wtforms.fields.datetime import DateTimeLocalField
 from flask_wtf.file import FileField
 from wtforms.validators import DataRequired, Length, Email, Optional
 from wtforms.fields import HiddenField, TelField
-from wtforms import IntegerField, TextAreaField
+from wtforms import IntegerField
 
 
 class CoachForm(FlaskForm):


### PR DESCRIPTION
## Summary
- remove `TextAreaField` from the forms module import list
- run `flake8` to confirm no unused imports remain

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_6880c9eecb24832a92dcf0279da11e98