### PR TITLE
Update migration to set encryption defaults

### DIFF
--- a/migrations/versions/0a22bf1e7c3b_add_encryption_column.py
+++ b/migrations/versions/0a22bf1e7c3b_add_encryption_column.py
@@ -17,9 +17,9 @@ depends_on = None
 def upgrade():
     op.add_column(
         'email_settings',
-        sa.Column('encryption', sa.String(length=10), nullable=True, server_default='tls'),
+        sa.Column('encryption', sa.String(length=10), nullable=True),
     )
-    op.alter_column('email_settings', 'encryption', server_default=None)
+    op.execute("UPDATE email_settings SET encryption='tls' WHERE encryption IS NULL")
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- modify upgrade() for encryption migration to avoid altering default
- update rows to use `tls` value immediately after adding the column

## Testing
- `flake8 | head -n 5`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880ea49feb8832aa1991921190c318f