### PR TITLE
Fix encryption column migration

### DIFF
--- a/migrations/versions/0a22bf1e7c3b_add_encryption_column.py
+++ b/migrations/versions/0a22bf1e7c3b_add_encryption_column.py
@@ -15,11 +15,16 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        'email_settings',
-        sa.Column('encryption', sa.String(length=10), nullable=True),
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_column('email_settings', 'encryption'):
+        op.add_column(
+            'email_settings',
+            sa.Column('encryption', sa.String(length=10), nullable=True),
+        )
+    op.execute(
+        "UPDATE email_settings SET encryption='tls' WHERE encryption IS NULL"
     )
-    op.execute("UPDATE email_settings SET encryption='tls' WHERE encryption IS NULL")
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- check if encryption column exists before adding it in migration

## Testing
- `flake8` *(fails: E501 line too long and other issues)*
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ef721bdc832aae824106f336a4a5