### PR TITLE
Fix Alembic has_column usage

### DIFF
--- a/migrations/versions/0a22bf1e7c3b_add_encryption_column.py
+++ b/migrations/versions/0a22bf1e7c3b_add_encryption_column.py
@@ -16,7 +16,9 @@ depends_on = None
 
 def upgrade():
     bind = op.get_bind()
-    if not bind.dialect.has_column(bind, 'email_settings', 'encryption'):
+    inspector = sa.inspect(bind)
+    columns = [c['name'] for c in inspector.get_columns('email_settings')]
+    if 'encryption' not in columns:
         op.add_column(
             'email_settings',
             sa.Column('encryption', sa.String(length=10), nullable=True),


### PR DESCRIPTION
## Summary
- use SQLAlchemy inspector to detect encryption column in migration

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f8fc207c832a8307cb061fb076dc