### PR TITLE
Normalize email lookups

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -33,15 +33,16 @@ def index():
             return redirect(url_for("routes.index"))
 
         # Sprawdzenie, czy podany adres e-mail jest już zarejestrowany
+        email = form.email.data.strip().lower()
         existing_volunteer = Volunteer.query.filter_by(
-            email=form.email.data.strip(),
+            email=email,
         ).first()
 
         if not existing_volunteer:
             existing_volunteer = Volunteer(
                 first_name=form.first_name.data.strip(),
                 last_name=form.last_name.data.strip(),
-                email=form.email.data.strip(),
+                email=email,
             )
             db.session.add(existing_volunteer)
             db.session.commit()
@@ -130,8 +131,9 @@ def cancel_booking():
             flash("Niepoprawny ID treningu", "danger")
             return redirect(url_for("routes.cancel_booking"))
 
+        email = form.email.data.strip().lower()
         volunteer = Volunteer.query.filter_by(
-            email=form.email.data.strip()
+            email=email
         ).first()
         if volunteer:
             booking = Booking.query.filter_by(

--- a/tests/test_case_insensitive_email.py
+++ b/tests/test_case_insensitive_email.py
@@ -1,0 +1,49 @@
+from app.models import Volunteer, Booking
+
+
+def sign_up(client, training_id, email):
+    return client.post(
+        '/',
+        data={
+            'first_name': 'Bob',
+            'last_name': 'Tester',
+            'email': email,
+            'training_id': str(training_id),
+        },
+        follow_redirects=True,
+    )
+
+
+def test_signup_stores_lowercase(client, app_instance, sample_data):
+    training_id, _, _, _ = sample_data
+    mixed_email = 'User@Example.COM'
+    sign_up(client, training_id, mixed_email)
+    with app_instance.app_context():
+        vol = Volunteer.query.filter_by(email=mixed_email.lower()).first()
+        assert vol is not None
+        assert vol.email == mixed_email.lower()
+
+
+def test_duplicate_signup_case_insensitive(client, app_instance, sample_data):
+    training_id, _, _, _ = sample_data
+    email = 'duplicate@example.com'
+    sign_up(client, training_id, email)
+    resp = sign_up(client, training_id, email.upper())
+    assert b'Jeste' in resp.data
+    with app_instance.app_context():
+        assert Booking.query.count() == 1
+        assert Volunteer.query.filter_by(email=email).count() == 1
+
+
+def test_cancel_case_insensitive(client, app_instance, sample_data):
+    training_id, _, _, _ = sample_data
+    email = 'cancelme@example.com'
+    sign_up(client, training_id, email)
+    resp = client.post(
+        f'/cancel?training_id={training_id}',
+        data={'email': email.upper(), 'training_id': training_id},
+        follow_redirects=True,
+    )
+    assert b'Zg' in resp.data
+    with app_instance.app_context():
+        assert Booking.query.count() == 0


### PR DESCRIPTION
## Summary
- normalize email addresses to lower-case on signup and cancellation
- test case-insensitive email handling

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810874c6c0832a8de89dde06f3897f