### PR TITLE
Use timezone-aware datetimes

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from . import db
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Coach(db.Model):
@@ -25,7 +25,7 @@ class Location(db.Model):
 class Training(db.Model):
     __tablename__ = 'trainings'
     id = db.Column(db.Integer, primary_key=True)
-    date = db.Column(db.DateTime, nullable=False)
+    date = db.Column(db.DateTime(timezone=True), nullable=False)
     location_id = db.Column(
         db.Integer,
         db.ForeignKey('locations.id'),
@@ -87,7 +87,10 @@ class Booking(db.Model):
         db.ForeignKey('volunteers.id'),
         nullable=False,
     )
-    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    timestamp = db.Column(
+        db.DateTime,
+        default=lambda: datetime.now(timezone.utc),
+    )
 
     training = db.relationship(
         'Training',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -39,7 +39,11 @@ def sample_data(app_instance):
         volunteer = Volunteer(
             first_name="Ann", last_name="Smith", email="ann@example.com"
         )
-        training = Training(date=datetime.utcnow(), coach=coach, location=location)
+        training = Training(
+            date=datetime.now(timezone.utc),
+            coach=coach,
+            location=location,
+        )
         db.session.add_all([coach, location, volunteer, training])
         db.session.commit()
         return training.id, volunteer.id, coach.id, location.id

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 
 from app import db
 from app.models import Coach, Location, Training, Volunteer, Booking
@@ -10,7 +10,11 @@ def setup_training(app):
     with app.app_context():
         coach = Coach(first_name='John', last_name='Doe', phone_number='123')
         location = Location(name='Court')
-        training = Training(date=datetime.utcnow(), coach=coach, location=location)
+        training = Training(
+            date=datetime.now(timezone.utc),
+            coach=coach,
+            location=location,
+        )
         volunteer = Volunteer(first_name='Ann', last_name='Smith', email='ann@example.com')
         db.session.add_all([coach, location, volunteer, training])
         db.session.commit()

--- a/tests/test_signup_cancel_admin.py
+++ b/tests/test_signup_cancel_admin.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from app import db
 from app.models import Booking, Training, Volunteer, Coach, Location
@@ -50,7 +50,9 @@ def test_admin_create_training(client, app_instance, sample_data):
     _, _, coach_id, location_id = sample_data
     login = client.post('/admin/login', data={'password': 'secret'}, follow_redirects=True)
     assert b'Zalogowano jako administrator.' in login.data
-    new_dt = (datetime.utcnow() + timedelta(days=1)).strftime('%Y-%m-%dT%H:%M')
+    new_dt = (
+        datetime.now(timezone.utc) + timedelta(days=1)
+    ).strftime('%Y-%m-%dT%H:%M')
     response = client.post(
         '/admin/trainings',
         data={'date': new_dt, 'location_id': location_id, 'coach_id': coach_id},


### PR DESCRIPTION
## Summary
- make `Training.date` timezone-aware
- store timezone-aware `Booking.timestamp`
- use `datetime.now(timezone.utc)` instead of deprecated `datetime.utcnow()`
- update tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810a85b96c832a9685e96d9bc7e491