### PR TITLE
Use hashed admin password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 FLASK_ENV=development
 LOG_LEVEL=INFO
 SECRET_KEY=your-secret-key
-ADMIN_PASSWORD=your-admin-password
+ADMIN_PASSWORD_HASH=your-admin-password-hash
 SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USERNAME=your-user

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This project provides a simple web application for organizing blind tennis train
 
 Create a `.env` file and define at least:
   - `SECRET_KEY` – Flask secret key.
-  - `ADMIN_PASSWORD` – password for the admin panel.
+  - `ADMIN_PASSWORD_HASH` – hashed password for the admin panel.
+    Generate a hash with `python generate_password_hash.py <password>`.
   - `SMTP_HOST` – outgoing mail server.
   - `SMTP_USERNAME` and `SMTP_PASSWORD` – credentials for the server.
   - `SMTP_SENDER` – email address used for outgoing mail.
@@ -118,7 +119,7 @@ After dropping the table re-run the upgrade or start the application again.
 
 ## Admin login
 
-The admin dashboard is accessible at `/admin/login`. Sign in using the password defined in the `ADMIN_PASSWORD` environment variable. Once logged in you can add or edit coaches, create trainings and export all data to Excel.
+The admin dashboard is accessible at `/admin/login`. Sign in using the password you hashed for the `ADMIN_PASSWORD_HASH` variable. Once logged in you can add or edit coaches, create trainings and export all data to Excel.
 
 ### Editing email templates
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,7 +42,7 @@ def create_app():
     )
     app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-    app.config['ADMIN_PASSWORD'] = os.environ.get("ADMIN_PASSWORD")
+    app.config['ADMIN_PASSWORD_HASH'] = os.environ.get("ADMIN_PASSWORD_HASH")
     app.config['SMTP_HOST'] = os.environ.get("SMTP_HOST")
     app.config['SMTP_PORT'] = int(os.environ.get("SMTP_PORT", 587))
     app.config['SMTP_USERNAME'] = os.environ.get("SMTP_USERNAME")

--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -11,6 +11,7 @@ from flask import (
 import flask
 from functools import wraps
 from datetime import datetime
+from werkzeug.security import check_password_hash
 
 from . import db, csrf
 from .email_utils import send_email
@@ -49,7 +50,8 @@ def login():
     form = LoginForm()
 
     if form.validate_on_submit():
-        if form.password.data == current_app.config["ADMIN_PASSWORD"]:
+        stored_hash = current_app.config.get("ADMIN_PASSWORD_HASH")
+        if stored_hash and check_password_hash(stored_hash, form.password.data):
             session["admin_logged_in"] = True
             flash("Zalogowano jako administrator.", "success")
             return redirect(url_for("admin.manage_trainings"))

--- a/generate_password_hash.py
+++ b/generate_password_hash.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Generate a werkzeug password hash from the provided password."""
+from werkzeug.security import generate_password_hash
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: python generate_password_hash.py <password>")
+    sys.exit(1)
+
+print(generate_password_hash(sys.argv[1]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,12 @@ from app.models import Coach, Location, Training, Volunteer
 
 @pytest.fixture
 def app_instance(monkeypatch):
+    from werkzeug.security import generate_password_hash
+
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
-    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    monkeypatch.setenv(
+        "ADMIN_PASSWORD_HASH", generate_password_hash("secret")
+    )
     app = create_app()
     app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
     with app.app_context():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -15,8 +15,10 @@ def test_default_log_level(monkeypatch):
     logging.getLogger("app").setLevel(logging.NOTSET)
     monkeypatch.delenv("LOG_LEVEL", raising=False)
     monkeypatch.setenv("FLASK_ENV", "development")
+    from werkzeug.security import generate_password_hash
+
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
-    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    monkeypatch.setenv("ADMIN_PASSWORD_HASH", generate_password_hash("secret"))
     app = create_app()
     assert app.logger.level == logging.INFO
 
@@ -25,8 +27,10 @@ def test_valid_log_level(monkeypatch):
     logging.getLogger("app").setLevel(logging.NOTSET)
     monkeypatch.setenv("LOG_LEVEL", "debug")
     monkeypatch.setenv("FLASK_ENV", "production")
+    from werkzeug.security import generate_password_hash
+
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
-    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    monkeypatch.setenv("ADMIN_PASSWORD_HASH", generate_password_hash("secret"))
     app = create_app()
     assert app.logger.level == logging.DEBUG
 
@@ -35,8 +39,10 @@ def test_invalid_log_level(monkeypatch, caplog):
     logging.getLogger("app").setLevel(logging.NOTSET)
     monkeypatch.setenv("LOG_LEVEL", "nope")
     monkeypatch.setenv("FLASK_ENV", "production")
+    from werkzeug.security import generate_password_hash
+
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
-    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    monkeypatch.setenv("ADMIN_PASSWORD_HASH", generate_password_hash("secret"))
     with caplog.at_level(logging.WARNING):
         app = create_app()
     assert any("Invalid LOG_LEVEL" in r.getMessage() for r in caplog.records)
@@ -46,8 +52,10 @@ def test_invalid_log_level(monkeypatch, caplog):
 def test_send_email_emits_info(monkeypatch, caplog):
     logging.getLogger("app").setLevel(logging.NOTSET)
     monkeypatch.setenv("LOG_LEVEL", "INFO")
+    from werkzeug.security import generate_password_hash
+
     monkeypatch.setenv("SQLALCHEMY_DATABASE_URI", "sqlite:///:memory:")
-    monkeypatch.setenv("ADMIN_PASSWORD", "secret")
+    monkeypatch.setenv("ADMIN_PASSWORD_HASH", generate_password_hash("secret"))
     app = create_app()
 
     class DummySMTP:


### PR DESCRIPTION
## Summary
- store hashed password in `ADMIN_PASSWORD_HASH`
- verify admin password via `check_password_hash`
- update tests for new variable
- document how to create a password hash and provide a helper script

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810e0071c0832ab2e7c9d66aa2487f