### PR TITLE
Add {logo} variable for email templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ The admin dashboard is accessible at `/admin/login`. Sign in using the password 
 
 ### Editing email templates
 
-Visit `/admin/settings` to configure SMTP details, set the sender display name and edit the messages sent to volunteers. The WYSIWYG editor lets you insert variables such as `{first_name}`, `{last_name}`, `{training}`, `{cancel_link}`, `{date}` and `{location}`. Use the **Podgląd** button to preview a template with example data before saving. Clicking the button posts the current editor content to `/admin/settings/preview/<template>` so you can check the result without modifying the stored template.
+Visit `/admin/settings` to configure SMTP details, set the sender display name and edit the messages sent to volunteers. The WYSIWYG editor lets you insert variables such as `{first_name}`, `{last_name}`, `{training}`, `{cancel_link}`, `{date}`, `{location}` and `{logo}`. The `{logo}` placeholder expands to the absolute URL of `static/logo.png`. Use the **Podgląd** button to preview a template with example data before saving. Clicking the button posts the current editor content to `/admin/settings/preview/<template>` so you can check the result without modifying the stored template.
 

--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -232,6 +232,7 @@ def cancel_training(training_id):
     data = {
         "date": training.date.strftime("%Y-%m-%d %H:%M"),
         "location": training.location.name,
+        "logo": url_for("static", filename="logo.png", _external=True),
     }
     if body_template:
         html_body = render_template_string(body_template, data)
@@ -489,6 +490,7 @@ def preview_template(template):
         "cancel_link": "https://example.com/cancel",
         "date": "2024-01-01 10:00",
         "location": "Warszawa",
+        "logo": url_for("static", filename="logo.png", _external=True),
     }
     html = render_template_string(tpl, data)
     return render_template("admin/preview_email.html", html=html)

--- a/app/routes.py
+++ b/app/routes.py
@@ -82,6 +82,7 @@ def index():
                 "cancel_link": cancel_link,
                 "date": training.date.strftime("%Y-%m-%d %H:%M"),
                 "location": training.location.name,
+                "logo": url_for("static", filename="logo.png", _external=True),
             }
             html_body = render_template_string(
                 settings.registration_template, data

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -45,7 +45,7 @@
       <div id="registration_editor" class="quill-wrapper" style="height:200px;"></div>
       <textarea id="registration_editor_textarea" class="form-control d-none" style="height:200px;"></textarea>
       <div class="mt-2">
-        {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}'] %}
+        {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}', '{logo}'] %}
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="registration_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
         <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="registration" data-editor="registration_editor">Podgląd</button>
@@ -61,7 +61,7 @@
       <div id="cancellation_editor" class="quill-wrapper" style="height:200px;"></div>
       <textarea id="cancellation_editor_textarea" class="form-control d-none" style="height:200px;"></textarea>
       <div class="mt-2">
-        {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}'] %}
+        {% for var in ['{first_name}', '{last_name}', '{training}', '{cancel_link}', '{date}', '{location}', '{logo}'] %}
         <button type="button" class="btn btn-sm btn-secondary insert-var" data-editor="cancellation_editor" data-value="{{ var }}">{{ var }}</button>
         {% endfor %}
         <button type="button" class="btn btn-sm btn-outline-primary ms-2 preview-btn" data-template="cancellation" data-editor="cancellation_editor">Podgląd</button>

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -55,12 +55,14 @@ def test_preview_endpoint_renders(client, app_instance):
     with client.session_transaction() as sess:
         sess['admin_logged_in'] = True
     with app_instance.app_context():
-        settings = EmailSettings(id=1, port=587, sender='Admin', encryption='tls', registration_template='Hi {first_name}', cancellation_template='')
+        settings = EmailSettings(id=1, port=587, sender='Admin', encryption='tls',
+                                 registration_template='Hi {first_name} {logo}', cancellation_template='')
         db.session.add(settings)
         db.session.commit()
     resp = client.get('/admin/settings/preview/registration')
     assert resp.status_code == 200
     assert b'Hi Jan' in resp.data
+    assert b'static/logo.png' in resp.data
 
 
 def test_preview_endpoint_allows_posting_html(client, app_instance):

--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -17,8 +17,10 @@ def test_preview_logged_in(client, app_instance):
     with client.session_transaction() as sess:
         sess['admin_logged_in'] = True
     with app_instance.app_context():
-        settings = EmailSettings(id=1, port=587, sender='Admin', registration_template='Hello {first_name}', cancellation_template='')
+        settings = EmailSettings(id=1, port=587, sender='Admin',
+                                 registration_template='Hello {first_name} {logo}', cancellation_template='')
         db.session.add(settings)
         db.session.commit()
     resp = client.get('/admin/settings/preview/registration')
     assert b'Hello' in resp.data
+    assert b'static/logo.png' in resp.data


### PR DESCRIPTION
## Summary
- expose a `{logo}` placeholder for registration/cancellation emails
- include logo URL in email routes and template preview
- show `{logo}` in settings variable buttons
- document new placeholder in README
- extend email preview tests for logo substitution

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812979c104832abd9a4b67270e4a53