### PR TITLE
Fix HTML editor saving

### DIFF
--- a/static/js/email_editor.js
+++ b/static/js/email_editor.js
@@ -24,9 +24,14 @@ window.addEventListener('DOMContentLoaded', () => {
     const container = document.getElementById(editorId);
 
     if (toggleSwitch && textarea) {
+      let initialized = false;
       const update = () => {
         if (toggleSwitch.checked) {
-          textarea.value = quill.root.innerHTML;
+          if (initialized) {
+            textarea.value = quill.root.innerHTML;
+          } else {
+            textarea.value = field.value;
+          }
           textarea.classList.remove('d-none');
           container.classList.add('d-none');
         } else {
@@ -34,6 +39,7 @@ window.addEventListener('DOMContentLoaded', () => {
           textarea.classList.add('d-none');
           container.classList.remove('d-none');
         }
+        initialized = true;
       };
       toggleSwitch.addEventListener('change', update);
       if (toggleSwitch.checked) {


### PR DESCRIPTION
## Summary
- preserve original template HTML on first load when HTML editor is enabled

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880b1f2cd14832ab74c61317d9210df