### PR TITLE
Filter out past trainings on index page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request
+from datetime import datetime, timezone
 from .models import Training, Booking, Volunteer, EmailSettings
 from .forms import VolunteerForm, CancelForm
 from . import db
@@ -104,6 +105,7 @@ def index():
     # Pogrupuj treningi według miesiąca
     trainings = (
         Training.query.filter_by(is_deleted=False)
+        .filter(Training.date >= datetime.now(timezone.utc))
         .order_by(Training.date)
         .all()
     )


### PR DESCRIPTION
## Summary
- keep only upcoming trainings in `routes.index()`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883c9639a20832aa3971da5be8305a5