### PR TITLE
Add capacity field for trainings

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -174,6 +174,7 @@ def manage_trainings():
             date=form.date.data,
             location_id=form.location_id.data,
             coach_id=form.coach_id.data,
+            max_volunteers=form.max_volunteers.data,
         )
         db.session.add(new_training)
         db.session.commit()
@@ -205,6 +206,7 @@ def edit_training(training_id):
         training.date = form.date.data
         training.location_id = form.location_id.data
         training.coach_id = form.coach_id.data
+        training.max_volunteers = form.max_volunteers.data
         db.session.commit()
         flash("Zaktualizowano trening.", "success")
         return redirect(url_for("admin.manage_trainings"))

--- a/app/forms.py
+++ b/app/forms.py
@@ -7,7 +7,7 @@ from wtforms import (
 )
 from wtforms.fields.datetime import DateTimeLocalField
 from flask_wtf.file import FileField
-from wtforms.validators import DataRequired, Length, Email, Optional
+from wtforms.validators import DataRequired, Length, Email, Optional, NumberRange
 from wtforms.fields import HiddenField, TelField
 from wtforms import IntegerField
 
@@ -37,6 +37,11 @@ class TrainingForm(FlaskForm):
     )
     coach_id = SelectField(
         'Trener', coerce=int, validators=[DataRequired()]
+    )
+    max_volunteers = IntegerField(
+        'Liczba miejsc',
+        default=2,
+        validators=[DataRequired(), NumberRange(min=1, max=20)],
     )
     submit = SubmitField('Zapisz')
 

--- a/app/templates/admin/edit_training.html
+++ b/app/templates/admin/edit_training.html
@@ -17,6 +17,10 @@
         {{ form.coach_id.label(class="form-label") }}
         {{ form.coach_id(class="form-select") }}
       </div>
+      <div class="col-auto col-lg-2">
+        {{ form.max_volunteers.label(class="form-label") }}
+        {{ form.max_volunteers(class="form-control") }}
+      </div>
       <div class="col-auto">
         <button class="btn btn-primary">Zapisz zmiany</button>
         <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-secondary ms-2">Anuluj</a>

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -26,6 +26,10 @@
         {{ form.coach_id.label(class="form-label") }}
         {{ form.coach_id(class="form-select") }}
       </div>
+      <div class="col-auto col-lg-2">
+        {{ form.max_volunteers.label(class="form-label") }}
+        {{ form.max_volunteers(class="form-control") }}
+      </div>
       <div class="col-auto">
         <button class="btn btn-success">Dodaj trening</button>
       </div>


### PR DESCRIPTION
## Summary
- let admin choose session size when creating/editing
- show `max_volunteers` input in admin templates
- persist `max_volunteers` field in training creation and editing

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883f1cf4a68832a9fd7b965d6cd34d6