### PR TITLE
Add trainer deletion route with admin UI and tests

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -106,6 +106,23 @@ def edit_trainer(coach_id):
     return render_template("admin/edit_trainer.html", form=form, coach=coach)
 
 
+@admin_bp.route("/trainers/<int:coach_id>/delete", methods=["POST"])
+@login_required
+def delete_trainer(coach_id):
+    coach = Coach.query.get_or_404(coach_id)
+    if coach.trainings:
+        flash(
+            "Nie można usunąć trenera powiązanego z treningami.",
+            "warning",
+        )
+        return redirect(url_for("admin.manage_trainers"))
+
+    db.session.delete(coach)
+    db.session.commit()
+    flash("Trener został usunięty.", "info")
+    return redirect(url_for("admin.manage_trainers"))
+
+
 @admin_bp.route("/locations", methods=["GET", "POST"])
 @login_required
 def manage_locations():

--- a/app/templates/admin/trainers.html
+++ b/app/templates/admin/trainers.html
@@ -34,6 +34,12 @@
             <a href="{{ url_for('admin.edit_trainer', coach_id=coach.id) }}" class="btn btn-sm btn-outline-primary" title="Edytuj">
               <i class="bi bi-pencil"></i>
             </a>
+            <form method="POST" action="{{ url_for('admin.delete_trainer', coach_id=coach.id) }}" class="d-inline">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button class="btn btn-sm btn-outline-secondary" title="Usuń">
+                <i class="bi bi-trash"></i>
+              </button>
+            </form>
           </td>
         </tr>
       {% endfor %}

--- a/tests/test_delete_trainer.py
+++ b/tests/test_delete_trainer.py
@@ -1,0 +1,21 @@
+import pytest
+from app import db
+from app.models import Coach
+
+
+def test_delete_trainer(client, app_instance):
+    with app_instance.app_context():
+        coach = Coach(first_name="Temp", last_name="Coach", phone_number="000")
+        db.session.add(coach)
+        db.session.commit()
+        coach_id = coach.id
+
+    login = client.post("/admin/login", data={"password": "secret"}, follow_redirects=True)
+    assert login.status_code == 200
+
+    resp = client.post(f"/admin/trainers/{coach_id}/delete", follow_redirects=True)
+    assert resp.status_code == 200
+    assert "Trener został usunięty." in resp.get_data(as_text=True)
+
+    with app_instance.app_context():
+        assert db.session.get(Coach, coach_id) is None


### PR DESCRIPTION
## Summary
- allow admins to delete trainers that have no trainings
- add delete button with CSRF token in trainer list
- cover trainer deletion with a test

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d1703db8832a96145558f6075f1e