### PR TITLE
Add location deletion route and test

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -145,6 +145,19 @@ def edit_location(location_id):
     )
 
 
+@admin_bp.route("/locations/<int:location_id>/delete", methods=["POST"])
+@login_required
+def delete_location(location_id):
+    location = Location.query.get_or_404(location_id)
+    if location.trainings:
+        flash("Nie można usunąć miejsca, ponieważ jest używane.", "warning")
+        return redirect(url_for("admin.manage_locations"))
+    db.session.delete(location)
+    db.session.commit()
+    flash("Miejsce zostało usunięte.", "info")
+    return redirect(url_for("admin.manage_locations"))
+
+
 @admin_bp.route("/trainings", methods=["GET", "POST"])
 @login_required
 def manage_trainings():

--- a/app/templates/admin/locations.html
+++ b/app/templates/admin/locations.html
@@ -25,6 +25,12 @@
           <a href="{{ url_for('admin.edit_location', location_id=location.id) }}" class="btn btn-sm btn-outline-primary" title="Edytuj">
             <i class="bi bi-pencil"></i>
           </a>
+          <form method="post" action="{{ url_for('admin.delete_location', location_id=location.id) }}" class="d-inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button class="btn btn-sm btn-outline-secondary" title="Usuń">
+              <i class="bi bi-trash"></i>
+            </button>
+          </form>
         </td>
       </tr>
       {% endfor %}

--- a/tests/test_delete_location.py
+++ b/tests/test_delete_location.py
@@ -1,0 +1,22 @@
+from app import db
+from app.models import Location
+
+
+def test_delete_location_removes_record(client, app_instance):
+    with app_instance.app_context():
+        location = Location(name="Hall")
+        db.session.add(location)
+        db.session.commit()
+        loc_id = location.id
+
+    with client.session_transaction() as sess:
+        sess["admin_logged_in"] = True
+
+    response = client.post(
+        f"/admin/locations/{loc_id}/delete",
+        follow_redirects=True,
+    )
+
+    assert "Miejsce zostało usunięte." in response.get_data(as_text=True)
+    with app_instance.app_context():
+        assert db.session.get(Location, loc_id) is None


### PR DESCRIPTION
## Summary
- allow admins to delete training locations when unused
- show delete option in location list
- test location deletion route

## Testing
- `flake8 --max-line-length=120 app/admin_routes.py tests/test_delete_location.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4ffa728832aae77d04bb2cd2dc8