### PR TITLE
Add adult status field for volunteers

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -4,10 +4,18 @@ from wtforms import (
     SubmitField,
     SelectField,
     PasswordField,
+    RadioField,
 )
 from wtforms.fields.datetime import DateTimeLocalField
 from flask_wtf.file import FileField
-from wtforms.validators import DataRequired, Length, Email, Optional, NumberRange
+from wtforms.validators import (
+    DataRequired,
+    Length,
+    Email,
+    Optional,
+    NumberRange,
+    InputRequired,
+)
 from wtforms.fields import HiddenField, TelField
 from wtforms import IntegerField
 
@@ -55,6 +63,12 @@ class VolunteerForm(FlaskForm):
     )
     email = StringField(
         'Email', validators=[DataRequired(), Email(), Length(max=128)]
+    )
+    is_adult = RadioField(
+        'Czy jesteś pełnoletni?',
+        choices=[('true', 'Tak'), ('false', 'Nie')],
+        coerce=lambda value: value == 'true',
+        validators=[InputRequired()],
     )
     training_id = HiddenField()  # ukryte pole – ID treningu
     submit = SubmitField('Zapisz się')

--- a/app/models.py
+++ b/app/models.py
@@ -84,6 +84,7 @@ class Volunteer(db.Model):
     first_name = db.Column(db.String(64), nullable=False)
     last_name = db.Column(db.String(64), nullable=False)
     email = db.Column(db.String(128), nullable=False, unique=True)
+    is_adult = db.Column(db.Boolean, nullable=True)
 
     def __repr__(self):
         return f"<Volunteer {self.first_name} {self.last_name}>"

--- a/app/routes.py
+++ b/app/routes.py
@@ -40,14 +40,24 @@ def index():
             email=email,
         ).first()
 
+        first_name = form.first_name.data.strip()
+        last_name = form.last_name.data.strip()
+
         if not existing_volunteer:
             existing_volunteer = Volunteer(
-                first_name=form.first_name.data.strip(),
-                last_name=form.last_name.data.strip(),
+                first_name=first_name,
+                last_name=last_name,
                 email=email,
             )
             db.session.add(existing_volunteer)
-            db.session.commit()
+        else:
+            existing_volunteer.first_name = first_name
+            existing_volunteer.last_name = last_name
+
+        existing_volunteer.is_adult = form.is_adult.data
+
+        if existing_volunteer.id is None:
+            db.session.flush()
 
         existing_booking = Booking.query.filter_by(
             training_id=training.id,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -72,6 +72,16 @@
               {{ form.email.label(class="form-label") }}
               {{ form.email(class="form-control") }}
             </div>
+            <div class="mb-3">
+              {{ form.is_adult.label(class="form-label d-block") }}
+              {% for subfield in form.is_adult %}
+              <div class="form-check">
+                {{ subfield(class="form-check-input", id=subfield.id) }}
+                <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+              </div>
+              {% endfor %}
+            </div>
+            <p class="text-muted small">Dane potrzebne są do dokumentacji.</p>
             {{ form.training_id }}
           </div>
           <div class="modal-footer">

--- a/migrations/versions/8e98b1a58d08_add_is_adult_to_volunteers.py
+++ b/migrations/versions/8e98b1a58d08_add_is_adult_to_volunteers.py
@@ -1,0 +1,26 @@
+"""add is_adult to volunteers
+
+Revision ID: 8e98b1a58d08
+Revises: 3fb4e7c905e4
+Create Date: 2023-01-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8e98b1a58d08'
+down_revision = '3fb4e7c905e4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('volunteers', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('is_adult', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('volunteers', schema=None) as batch_op:
+        batch_op.drop_column('is_adult')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,10 @@ def sample_data(app_instance):
         coach = Coach(first_name="John", last_name="Doe", phone_number="123")
         location = Location(name="Court")
         volunteer = Volunteer(
-            first_name="Ann", last_name="Smith", email="ann@example.com"
+            first_name="Ann",
+            last_name="Smith",
+            email="ann@example.com",
+            is_adult=True,
         )
         training = Training(
             date=datetime.now(timezone.utc),

--- a/tests/test_case_insensitive_email.py
+++ b/tests/test_case_insensitive_email.py
@@ -1,7 +1,7 @@
 from app.models import Volunteer, Booking
 
 
-def sign_up(client, training_id, email):
+def sign_up(client, training_id, email, is_adult=True):
     return client.post(
         '/',
         data={
@@ -9,6 +9,7 @@ def sign_up(client, training_id, email):
             'last_name': 'Tester',
             'email': email,
             'training_id': str(training_id),
+            'is_adult': 'true' if is_adult else 'false',
         },
         follow_redirects=True,
     )
@@ -17,28 +18,31 @@ def sign_up(client, training_id, email):
 def test_signup_stores_lowercase(client, app_instance, sample_data):
     training_id, _, _, _ = sample_data
     mixed_email = 'User@Example.COM'
-    sign_up(client, training_id, mixed_email)
+    sign_up(client, training_id, mixed_email, is_adult=True)
     with app_instance.app_context():
         vol = Volunteer.query.filter_by(email=mixed_email.lower()).first()
         assert vol is not None
         assert vol.email == mixed_email.lower()
+        assert vol.is_adult is True
 
 
 def test_duplicate_signup_case_insensitive(client, app_instance, sample_data):
     training_id, _, _, _ = sample_data
     email = 'duplicate@example.com'
-    sign_up(client, training_id, email)
-    resp = sign_up(client, training_id, email.upper())
+    sign_up(client, training_id, email, is_adult=False)
+    resp = sign_up(client, training_id, email.upper(), is_adult=False)
     assert b'Jeste' in resp.data
     with app_instance.app_context():
         assert Booking.query.count() == 1
         assert Volunteer.query.filter_by(email=email).count() == 1
+        volunteer = Volunteer.query.filter_by(email=email).first()
+        assert volunteer.is_adult is False
 
 
 def test_cancel_case_insensitive(client, app_instance, sample_data):
     training_id, _, _, _ = sample_data
     email = 'cancelme@example.com'
-    sign_up(client, training_id, email)
+    sign_up(client, training_id, email, is_adult=False)
     resp = client.post(
         f'/cancel?training_id={training_id}',
         data={'email': email.upper(), 'training_id': training_id},
@@ -47,3 +51,6 @@ def test_cancel_case_insensitive(client, app_instance, sample_data):
     assert b'Zg' in resp.data
     with app_instance.app_context():
         assert Booking.query.count() == 0
+        volunteer = Volunteer.query.filter_by(email=email.lower()).first()
+        assert volunteer is not None
+        assert volunteer.is_adult is False

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,7 +15,12 @@ def setup_training(app):
             coach=coach,
             location=location,
         )
-        volunteer = Volunteer(first_name='Ann', last_name='Smith', email='ann@example.com')
+        volunteer = Volunteer(
+            first_name='Ann',
+            last_name='Smith',
+            email='ann@example.com',
+            is_adult=True,
+        )
         db.session.add_all([coach, location, volunteer, training])
         db.session.commit()
         return training.id, volunteer.id
@@ -36,6 +41,7 @@ def test_duplicate_booking_flash(client, app_instance):
             'last_name': 'Smith',
             'email': 'ann@example.com',
             'training_id': str(training_id),
+            'is_adult': 'true',
         },
         follow_redirects=True,
     )
@@ -43,6 +49,8 @@ def test_duplicate_booking_flash(client, app_instance):
     assert b'Jeste' in response.data
     with app_instance.app_context():
         assert Booking.query.count() == 1
+        volunteer = db.session.get(Volunteer, volunteer_id)
+        assert volunteer.is_adult is True
 
 
 def test_deleted_training_shows_in_history(client, app_instance):


### PR DESCRIPTION
## Summary
- add a required adult-status control to the volunteer signup form and surface the documentation note in the modal
- persist the new `is_adult` flag on volunteers, including an Alembic migration and route updates
- adjust signup-related tests to post the flag and assert its stored value

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca831daf7c832a923f3e636bfcb4ea