### PR TITLE
Add attachment management to admin email settings

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -6,10 +6,18 @@ from wtforms import (
     PasswordField,
 )
 from wtforms.fields.datetime import DateTimeLocalField
-from flask_wtf.file import FileField
+from flask_wtf.file import FileField, MultipleFileField
 from wtforms.validators import DataRequired, Length, Email, Optional, NumberRange
 from wtforms.fields import HiddenField, TelField
+from wtforms import SelectMultipleField, widgets
 from wtforms import IntegerField
+
+
+
+
+class MultiCheckboxField(SelectMultipleField):
+    widget = widgets.ListWidget(prefix_label=False)
+    option_widget = widgets.CheckboxInput()
 
 
 class CoachForm(FlaskForm):
@@ -106,6 +114,24 @@ class SettingsForm(FlaskForm):
     )
     registration_template = HiddenField('Szablon maila zapisu')
     cancellation_template = HiddenField('Szablon maila odwołania')
+    adult_attachments = MultipleFileField(
+        'Załączniki (dorośli)', validators=[Optional()]
+    )
+    remove_adult_attachments = MultiCheckboxField(
+        'Usuń załączniki (dorośli)',
+        choices=[],
+        coerce=str,
+        validators=[Optional()],
+    )
+    minor_attachments = MultipleFileField(
+        'Załączniki (nieletni)', validators=[Optional()]
+    )
+    remove_minor_attachments = MultiCheckboxField(
+        'Usuń załączniki (nieletni)',
+        choices=[],
+        coerce=str,
+        validators=[Optional()],
+    )
     test_recipient = StringField(
         'Adres testowy', validators=[Optional(), Email(), Length(max=128)]
     )

--- a/app/models.py
+++ b/app/models.py
@@ -150,6 +150,8 @@ class EmailSettings(db.Model):
     encryption = db.Column(db.String(10), nullable=True)
     registration_template = db.Column(db.Text, nullable=True)
     cancellation_template = db.Column(db.Text, nullable=True)
+    adult_attachments = db.Column(db.JSON, default=list)
+    minor_attachments = db.Column(db.JSON, default=list)
 
 
 @event.listens_for(Training.__table__, "before_create")

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -2,7 +2,7 @@
 {% block admin_content %}
 <div class="container mt-4">
   <h2>Ustawienia e-mail</h2>
-  <form method="POST">
+  <form method="POST" enctype="multipart/form-data">
     {{ form.csrf_token }}
     <div class="row g-2">
       <div class="col-md-4">
@@ -52,6 +52,78 @@
         <div class="form-check form-switch d-inline-block ms-2">
           <input class="form-check-input html-toggle" type="checkbox" role="switch" id="registration_html_toggle" data-editor="registration_editor">
           <label class="form-check-label" for="registration_html_toggle">Edytuj HTML</label>
+        </div>
+      </div>
+    </div>
+    <div class="row g-4 mt-3">
+      <div class="col-md-6">
+        <h5 class="mb-3">Załączniki (dorośli)</h5>
+        <div class="mb-3">
+          {{ form.adult_attachments.label(class="form-label") }}
+          {{ form.adult_attachments(class_="form-control", multiple=True) }}
+          <div class="form-text">Możesz dodać wiele plików jednocześnie.</div>
+        </div>
+        <div class="mb-2">
+          <h6 class="fw-semibold">{{ form.remove_adult_attachments.label.text }}</h6>
+          {% if adult_attachments %}
+          <ul class="list-group">
+            {% for checkbox in form.remove_adult_attachments %}
+            {% set meta = adult_attachments[loop.index0] %}
+            {% set display_name = meta.get('original_name') or meta.get('filename') %}
+            {% set content_type = meta.get('content_type') %}
+            {% set size = meta.get('size') %}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <div>
+                <div>{{ display_name }}</div>
+                <div class="small text-muted">
+                  {{ content_type or 'application/octet-stream' }}{% if size is not none %} • {{ size }} B{% endif %}
+                </div>
+              </div>
+              <div class="form-check m-0">
+                {{ checkbox(class_="form-check-input") }}
+                <label class="form-check-label" for="{{ checkbox.id }}">Usuń</label>
+              </div>
+            </li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <p class="text-muted mb-0">Brak zapisanych załączników.</p>
+          {% endif %}
+        </div>
+      </div>
+      <div class="col-md-6">
+        <h5 class="mb-3">Załączniki (nieletni)</h5>
+        <div class="mb-3">
+          {{ form.minor_attachments.label(class="form-label") }}
+          {{ form.minor_attachments(class_="form-control", multiple=True) }}
+          <div class="form-text">Dodaj pliki dla zapisów nieletnich.</div>
+        </div>
+        <div class="mb-2">
+          <h6 class="fw-semibold">{{ form.remove_minor_attachments.label.text }}</h6>
+          {% if minor_attachments %}
+          <ul class="list-group">
+            {% for checkbox in form.remove_minor_attachments %}
+            {% set meta = minor_attachments[loop.index0] %}
+            {% set display_name = meta.get('original_name') or meta.get('filename') %}
+            {% set content_type = meta.get('content_type') %}
+            {% set size = meta.get('size') %}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <div>
+                <div>{{ display_name }}</div>
+                <div class="small text-muted">
+                  {{ content_type or 'application/octet-stream' }}{% if size is not none %} • {{ size }} B{% endif %}
+                </div>
+              </div>
+              <div class="form-check m-0">
+                {{ checkbox(class_="form-check-input") }}
+                <label class="form-check-label" for="{{ checkbox.id }}">Usuń</label>
+              </div>
+            </li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <p class="text-muted mb-0">Brak zapisanych załączników.</p>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/migrations/versions/4ae0a2f4d8fd_add_attachment_metadata_to_email_settings.py
+++ b/migrations/versions/4ae0a2f4d8fd_add_attachment_metadata_to_email_settings.py
@@ -1,0 +1,31 @@
+"""add attachment metadata columns to email settings
+
+Revision ID: 4ae0a2f4d8fd
+Revises: 3fb4e7c905e4
+Create Date: 2025-08-05 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "4ae0a2f4d8fd"
+down_revision = "3fb4e7c905e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "email_settings",
+        sa.Column("adult_attachments", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "email_settings",
+        sa.Column("minor_attachments", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("email_settings", "minor_attachments")
+    op.drop_column("email_settings", "adult_attachments")


### PR DESCRIPTION
## Summary
- store adult and minor attachment metadata on email settings with a new migration
- extend the admin settings form, view, and template to upload and prune attachment files
- cover attachment persistence and removal in the admin settings tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8487e93c832a97645c4547a6508c