### PR TITLE
Add registration email attachments

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -4,6 +4,7 @@ from . import db
 import smtplib
 from email.message import EmailMessage
 import re
+from collections.abc import Iterable
 
 
 def send_email(
@@ -19,6 +20,7 @@ def send_email(
     sender: str | None = None,
     encryption: str | None = None,
     use_tls: bool | None = None,
+    attachments: Iterable[tuple[str, str, bytes]] | None = None,
 ) -> tuple[bool, str | None]:
     """Send an email using stored SMTP settings.
 
@@ -97,6 +99,18 @@ def send_email(
 
     if html_body:
         msg.add_alternative(html_body, subtype="html")
+
+    if attachments:
+        for filename, content_type, data in attachments:
+            maintype, subtype = (content_type.split("/", 1) + [""])[:2]
+            if not subtype:
+                maintype, subtype = "application", "octet-stream"
+            msg.add_attachment(
+                data,
+                maintype=maintype,
+                subtype=subtype,
+                filename=filename,
+            )
 
     try:
         smtp_cls = smtplib.SMTP_SSL if encryption == "ssl" else smtplib.SMTP

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from . import db
 from datetime import datetime, timezone
 from sqlalchemy import CheckConstraint, event
+from sqlalchemy import LargeBinary
 
 
 class Coach(db.Model):
@@ -151,6 +152,19 @@ class EmailSettings(db.Model):
     encryption = db.Column(db.String(10), nullable=True)
     registration_template = db.Column(db.Text, nullable=True)
     cancellation_template = db.Column(db.Text, nullable=True)
+    registration_files_adult = db.Column(db.JSON, nullable=True)
+    registration_files_minor = db.Column(db.JSON, nullable=True)
+
+
+class StoredFile(db.Model):
+    """Binary file stored in the database for email attachments."""
+
+    __tablename__ = "stored_files"
+
+    id = db.Column(db.Integer, primary_key=True)
+    filename = db.Column(db.String(256), nullable=False)
+    content_type = db.Column(db.String(128), nullable=False)
+    data = db.Column(LargeBinary, nullable=False)
 
 
 @event.listens_for(Training.__table__, "before_create")


### PR DESCRIPTION
## Summary
- allow send_email to include optional attachments and persist stored files
- attach adult or minor onboarding files when volunteers register
- expand tests to cover attachment selection and email contents

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca88c93984832a9f4ea5e5e2aa4fa5