### PR TITLE
Add admin controls for registration attachments

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -7,7 +7,7 @@ from wtforms import (
     RadioField,
 )
 from wtforms.fields.datetime import DateTimeLocalField
-from flask_wtf.file import FileField
+from flask_wtf.file import FileField, MultipleFileField
 from wtforms.validators import (
     DataRequired,
     Length,
@@ -18,6 +18,14 @@ from wtforms.validators import (
 )
 from wtforms.fields import HiddenField, TelField
 from wtforms import IntegerField
+from wtforms import SelectMultipleField, widgets
+
+
+class MultiCheckboxField(SelectMultipleField):
+    """Render a set of checkboxes representing a multi-select field."""
+
+    widget = widgets.ListWidget(prefix_label=False)
+    option_widget = widgets.CheckboxInput()
 
 
 class CoachForm(FlaskForm):
@@ -122,6 +130,18 @@ class SettingsForm(FlaskForm):
     cancellation_template = HiddenField('Szablon maila odwołania')
     test_recipient = StringField(
         'Adres testowy', validators=[Optional(), Email(), Length(max=128)]
+    )
+    registration_files_adult = MultipleFileField(
+        'Załączniki - osoba pełnoletnia', validators=[Optional()]
+    )
+    registration_files_minor = MultipleFileField(
+        'Załączniki - osoba niepełnoletnia', validators=[Optional()]
+    )
+    remove_adult_files = MultiCheckboxField(
+        'Usuń załączniki (pełnoletni)', choices=[], validators=[Optional()]
+    )
+    remove_minor_files = MultiCheckboxField(
+        'Usuń załączniki (niepełnoletni)', choices=[], validators=[Optional()]
     )
     submit = SubmitField('Zapisz')
     send_test = SubmitField('Wyślij test')

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -2,7 +2,7 @@
 {% block admin_content %}
 <div class="container mt-4">
   <h2>Ustawienia e-mail</h2>
-  <form method="POST">
+  <form method="POST" enctype="multipart/form-data">
     {{ form.csrf_token }}
     <div class="row g-2">
       <div class="col-md-4">
@@ -54,6 +54,44 @@
           <label class="form-check-label" for="registration_html_toggle">Edytuj HTML</label>
         </div>
       </div>
+    </div>
+    <div class="mb-3">
+      {{ form.registration_files_adult.label(class="form-label") }}
+      {{ form.registration_files_adult(class="form-control", multiple=True) }}
+      <div class="form-text">Dodaj dokumenty wysyłane do osób pełnoletnich.</div>
+      {% if form.remove_adult_files.choices %}
+      <div class="mt-2">
+        <p class="mb-1">Istniejące załączniki:</p>
+        {% for subfield in form.remove_adult_files %}
+        <div class="form-check">
+          {{ subfield(class="form-check-input", id=subfield.id) }}
+          <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+        </div>
+        {% endfor %}
+        <div class="form-text">Zaznacz pliki, które mają zostać usunięte.</div>
+      </div>
+      {% else %}
+      <div class="form-text">Brak zapisanych załączników dla osób pełnoletnich.</div>
+      {% endif %}
+    </div>
+    <div class="mb-3">
+      {{ form.registration_files_minor.label(class="form-label") }}
+      {{ form.registration_files_minor(class="form-control", multiple=True) }}
+      <div class="form-text">Dodaj dokumenty wysyłane do osób niepełnoletnich.</div>
+      {% if form.remove_minor_files.choices %}
+      <div class="mt-2">
+        <p class="mb-1">Istniejące załączniki:</p>
+        {% for subfield in form.remove_minor_files %}
+        <div class="form-check">
+          {{ subfield(class="form-check-input", id=subfield.id) }}
+          <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+        </div>
+        {% endfor %}
+        <div class="form-text">Zaznacz pliki, które mają zostać usunięte.</div>
+      </div>
+      {% else %}
+      <div class="form-text">Brak zapisanych załączników dla osób niepełnoletnich.</div>
+      {% endif %}
     </div>
     <div class="mb-3">
       {{ form.cancellation_template.label(class="form-label") }}

--- a/migrations/versions/6a564e5cf48a_add_registration_attachment_columns.py
+++ b/migrations/versions/6a564e5cf48a_add_registration_attachment_columns.py
@@ -1,0 +1,32 @@
+"""add registration attachment columns
+
+Revision ID: 6a564e5cf48a
+Revises: 8e98b1a58d08
+Create Date: 2025-07-15 21:37:37.159899
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6a564e5cf48a'
+down_revision = '8e98b1a58d08'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'email_settings',
+        sa.Column('registration_files_adult', sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        'email_settings',
+        sa.Column('registration_files_minor', sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column('email_settings', 'registration_files_minor')
+    op.drop_column('email_settings', 'registration_files_adult')


### PR DESCRIPTION
## Summary
- add database columns to store adult/minor registration attachment metadata
- extend the admin settings form, view, and template to upload and manage these attachment sets
- cover the new workflow with tests for uploading and removing configured files

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca815d8378832a8cb3e5a3179e94ff