### PR TITLE
Handle legacy attachment metadata when updating admin settings

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,10 +1,155 @@
-from flask import Blueprint, render_template, redirect, url_for, flash, request
+from flask import (
+    Blueprint,
+    current_app,
+    render_template,
+    redirect,
+    url_for,
+    flash,
+    request,
+)
 from datetime import datetime, timezone
+import base64
+import binascii
+from pathlib import Path
+from collections.abc import Iterable
+from sqlalchemy import select
 from .models import Training, Booking, Volunteer, EmailSettings, StoredFile
 from .forms import VolunteerForm, CancelForm
 from . import db
 from .email_utils import send_email
 from .template_utils import render_template_string
+
+
+def _decode_attachment_payload(raw: object) -> bytes | None:
+    """Convert a payload from JSON into raw bytes.
+
+    Legacy rows may still store attachment contents inline (as base64 or plain
+    text). The admin panel stores files on disk, so this is only used for
+    backwards compatibility.
+    """
+
+    if raw is None:
+        return None
+    if isinstance(raw, bytes):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return base64.b64decode(raw, validate=True)
+        except binascii.Error:
+            return raw.encode("utf-8")
+    if isinstance(raw, Iterable):
+        try:
+            return bytes(raw)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            try:
+                return int(stripped)
+            except ValueError:
+                return None
+    return None
+
+
+def _resolve_attachment_metadata(
+    attachments_meta: Iterable[object],
+) -> list[tuple[str, str, bytes]]:
+    """Resolve attachments referenced in the email settings.
+
+    Supports both the new metadata format stored by the admin panel and legacy
+    entries that point to ``StoredFile`` rows or embed file contents directly in
+    JSON. Missing files are ignored with a warning.
+    """
+
+    attachments: list[tuple[str, str, bytes]] = []
+    legacy_ids: set[int] = set()
+    file_metadatas: list[dict[str, object]] = []
+
+    for entry in attachments_meta:
+        if isinstance(entry, dict):
+            stored_name = entry.get("stored_name")
+            if stored_name:
+                file_metadatas.append(entry)
+                continue
+
+            file_id = _coerce_int(
+                entry.get("stored_file_id") or entry.get("id")
+            )
+            if file_id is not None:
+                legacy_ids.add(file_id)
+                continue
+
+            payload = _decode_attachment_payload(entry.get("data"))
+            if payload is None:
+                current_app.logger.warning(
+                    "Attachment metadata %s has no readable payload", entry
+                )
+                continue
+
+            filename = (
+                entry.get("original_name")
+                or entry.get("filename")
+                or "zalacznik"
+            )
+            content_type = entry.get("content_type") or "application/octet-stream"
+            attachments.append((str(filename), str(content_type), payload))
+            continue
+
+        file_id = _coerce_int(entry)
+        if file_id is not None:
+            legacy_ids.add(file_id)
+
+    if legacy_ids:
+        stored_rows = db.session.scalars(
+            select(StoredFile).where(StoredFile.id.in_(legacy_ids))
+        ).all()
+        stored_by_id = {row.id: row for row in stored_rows}
+        for file_id in legacy_ids:
+            stored_file = stored_by_id.get(file_id)
+            if not stored_file:
+                current_app.logger.warning(
+                    "Stored file with id %s referenced in settings but missing",
+                    file_id,
+                )
+                continue
+            attachments.append(
+                (
+                    stored_file.filename,
+                    stored_file.content_type,
+                    stored_file.data,
+                )
+            )
+
+    if file_metadatas:
+        attachments_dir = Path(current_app.instance_path) / "attachments"
+        for entry in file_metadatas:
+            stored_name = entry.get("stored_name")
+            if not stored_name:
+                continue
+            file_path = attachments_dir / str(stored_name)
+            try:
+                payload = file_path.read_bytes()
+            except OSError:
+                current_app.logger.warning(
+                    "Attachment file %s referenced in settings is missing", file_path
+                )
+                continue
+            filename = (
+                entry.get("original_name")
+                or entry.get("filename")
+                or str(stored_name)
+            )
+            content_type = entry.get("content_type") or "application/octet-stream"
+            attachments.append((str(filename), str(content_type), payload))
+
+    return attachments
 
 bp = Blueprint('routes', __name__)
 
@@ -100,25 +245,14 @@ def index():
             )
             attachments: list[tuple[str, str, bytes]] = []
             if settings:
-                file_ids: list[int] | None
-                if existing_volunteer.is_adult:
-                    file_ids = settings.registration_files_adult or []
-                else:
-                    file_ids = settings.registration_files_minor or []
-                if file_ids:
-                    stored = (
-                        StoredFile.query.filter(StoredFile.id.in_(file_ids)).all()
-                    )
-                    stored_by_id = {file.id: file for file in stored}
-                    attachments = [
-                        (
-                            stored_by_id[file_id].filename,
-                            stored_by_id[file_id].content_type,
-                            stored_by_id[file_id].data,
-                        )
-                        for file_id in file_ids
-                        if file_id in stored_by_id
-                    ]
+                attachments_meta = (
+                    settings.registration_files_adult
+                    if existing_volunteer.is_adult
+                    else settings.registration_files_minor
+                ) or []
+                attachments.extend(
+                    _resolve_attachment_metadata(attachments_meta)
+                )
 
             success, error = send_email(
                 "Potwierdzenie zgłoszenia",


### PR DESCRIPTION
## Summary
- make the admin settings form tolerant of legacy attachment metadata without stored file names
- ensure existing attachments are preserved while allowing removals for disk-backed files only
- add a regression test covering legacy attachment IDs when updating SMTP credentials

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ca9cb79c9c832a90fb821ed615b4f8