### PR TITLE
Handle missing test email recipient

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -585,29 +585,42 @@ def test_email():
     form.remove_adult_files.choices = []
     form.remove_minor_files.choices = []
     if form.validate_on_submit():
-        recipient = form.test_recipient.data.strip()
-        try:
-            success, error = send_email(
-                "Test konfiguracji",
-                "To jest testowa wiadomość.",
-                [recipient],
-                host=form.server.data or None,
-                port=form.port.data,
-                username=form.login.data or None,
-                password=form.password.data or None,
-                encryption=form.encryption.data,
-                sender=form.sender.data or None,
+        recipient_data = form.test_recipient.data
+        if not recipient_data:
+            flash(
+                "Podaj adres e-mail odbiorcy wiadomości testowej.",
+                "warning",
             )
-            if success:
-                flash("Wysłano wiadomość testową.", "success")
+        else:
+            recipient = recipient_data.strip()
+            if not recipient:
+                flash(
+                    "Podaj adres e-mail odbiorcy wiadomości testowej.",
+                    "warning",
+                )
             else:
-                msg = "Nie udało się wysłać wiadomości testowej"
-                if error:
-                    msg += f": {error}"
-                flash(msg, "danger")
-        except Exception:  # pragma: no cover - safety net
-            current_app.logger.exception("Failed to send test email")
-            flash("Nie udało się wysłać wiadomości testowej.", "danger")
+                try:
+                    success, error = send_email(
+                        "Test konfiguracji",
+                        "To jest testowa wiadomość.",
+                        [recipient],
+                        host=form.server.data or None,
+                        port=form.port.data,
+                        username=form.login.data or None,
+                        password=form.password.data or None,
+                        encryption=form.encryption.data,
+                        sender=form.sender.data or None,
+                    )
+                    if success:
+                        flash("Wysłano wiadomość testową.", "success")
+                    else:
+                        msg = "Nie udało się wysłać wiadomości testowej"
+                        if error:
+                            msg += f": {error}"
+                        flash(msg, "danger")
+                except Exception:  # pragma: no cover - safety net
+                    current_app.logger.exception("Failed to send test email")
+                    flash("Nie udało się wysłać wiadomości testowej.", "danger")
     else:
         flash("Nie udało się wysłać wiadomości testowej.", "danger")
     return render_template("admin/settings.html", form=form)


### PR DESCRIPTION
## Summary
- avoid calling strip on missing test email recipient input and surface a warning flash instead
- keep the warning when the trimmed value is empty and retain existing email sending logic when present
- add a regression test covering a missing recipient to ensure the view responds with status 200 and flashes the explanation

## Testing
- PYTHONPATH=. pytest tests/test_admin_settings.py -k "test_email" -q

------
https://chatgpt.com/codex/tasks/task_e_68cacbde471c832a830376cb01ab1de9