### PR TITLE
Add quick remove buttons for email attachments

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -63,9 +63,17 @@
       <div class="mt-2">
         <p class="mb-1">Istniejące załączniki:</p>
         {% for subfield in form.remove_adult_files %}
-        <div class="form-check">
-          {{ subfield(class="form-check-input", id=subfield.id) }}
-          <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+        <div class="d-flex align-items-center mb-1">
+          <div class="form-check mb-0">
+            {{ subfield(class="form-check-input", id=subfield.id) }}
+            <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+          </div>
+          <button type="button"
+                  class="btn btn-sm btn-outline-danger ms-2 remove-attachment-btn"
+                  data-target="{{ subfield.id }}"
+                  data-confirm="Czy na pewno chcesz usunąć ten załącznik?">
+            Usuń
+          </button>
         </div>
         {% endfor %}
         <div class="form-text">Zaznacz pliki, które mają zostać usunięte.</div>
@@ -82,9 +90,17 @@
       <div class="mt-2">
         <p class="mb-1">Istniejące załączniki:</p>
         {% for subfield in form.remove_minor_files %}
-        <div class="form-check">
-          {{ subfield(class="form-check-input", id=subfield.id) }}
-          <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+        <div class="d-flex align-items-center mb-1">
+          <div class="form-check mb-0">
+            {{ subfield(class="form-check-input", id=subfield.id) }}
+            <label class="form-check-label" for="{{ subfield.id }}">{{ subfield.label.text }}</label>
+          </div>
+          <button type="button"
+                  class="btn btn-sm btn-outline-danger ms-2 remove-attachment-btn"
+                  data-target="{{ subfield.id }}"
+                  data-confirm="Czy na pewno chcesz usunąć ten załącznik?">
+            Usuń
+          </button>
         </div>
         {% endfor %}
         <div class="form-text">Zaznacz pliki, które mają zostać usunięte.</div>
@@ -122,4 +138,34 @@
     </div>
   </div>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const buttons = document.querySelectorAll('.remove-attachment-btn');
+    const submitForm = function (form) {
+      if (typeof form.requestSubmit === 'function') {
+        form.requestSubmit();
+      } else {
+        HTMLFormElement.prototype.submit.call(form);
+      }
+    };
+
+    buttons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        const checkbox = document.getElementById(this.dataset.target);
+        if (!checkbox) {
+          return;
+        }
+        const message = this.dataset.confirm;
+        if (message && !window.confirm(message)) {
+          return;
+        }
+        checkbox.checked = true;
+        const form = checkbox.closest('form');
+        if (form) {
+          submitForm(form);
+        }
+      });
+    });
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add inline "Usuń" buttons next to existing email attachment entries in the admin settings view
- confirm deletion, check the corresponding checkbox and submit the form automatically for a smoother workflow
- use `requestSubmit()` when available (and fall back to the native prototype) so the auto-submit works with WTForms-generated submit inputs and still triggers submit handlers

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cadf62462c832a9ed23e6421e1192f