### PR TITLE
Fix duplicate remove attachment submission

### DIFF
--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -163,11 +163,7 @@
         checkbox.checked = true;
         const form = checkbox.closest('form');
         if (form) {
-
           submitForm(form);
-
-          form.submit();
-
         }
       });
     });


### PR DESCRIPTION
## Summary
- rely on the existing submitForm helper when removing attachments so the delete button only submits once

## Testing
- PYTHONPATH=. pytest tests/test_admin_settings.py::test_admin_settings_manage_attachments
- manual verification: removed an attachment via the admin UI and observed a single POST 302/200 in the network log

------
https://chatgpt.com/codex/tasks/task_e_68cb0f2e5998832a88ffa801f1678a02