### PR TITLE
Fix admin settings crash when submitting empty attachment fields

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -483,9 +483,18 @@ def settings():
         db.session.commit()
 
     form = SettingsForm(obj=settings)
-    if not flask.request.files.getlist("registration_files_adult"):
+    def _has_uploaded_files(field_name: str) -> bool:
+        """Return ``True`` when the request contains real file uploads."""
+
+        files = flask.request.files.getlist(field_name)
+        for storage in files:
+            if storage and getattr(storage, "filename", ""):
+                return True
+        return False
+
+    if not _has_uploaded_files("registration_files_adult"):
         form.registration_files_adult.data = []
-    if not flask.request.files.getlist("registration_files_minor"):
+    if not _has_uploaded_files("registration_files_minor"):
         form.registration_files_minor.data = []
 
     attachments_dir = Path(current_app.instance_path) / "attachments"


### PR DESCRIPTION
## Summary
- add a helper that checks whether the settings form contains actual file uploads
- reset attachment fields when the browser submits empty file inputs to avoid processing metadata as uploads

## Testing
- PYTHONPATH=/workspace/treningi pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb21f2a9a8832abc6c6faec063d388