### PR TITLE
Add repeat scheduling controls for trainings

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from flask_wtf import FlaskForm
 from wtforms import (
     StringField,
@@ -5,6 +7,7 @@ from wtforms import (
     SelectField,
     PasswordField,
     RadioField,
+    BooleanField,
 )
 from wtforms.fields.datetime import DateTimeLocalField
 from flask_wtf.file import FileField, MultipleFileField
@@ -60,7 +63,79 @@ class TrainingForm(FlaskForm):
         default=2,
         validators=[DataRequired(), NumberRange(min=1, max=20)],
     )
+    repeat = BooleanField('Powtarzaj')
+    repeat_interval = IntegerField(
+        'Odstęp (tygodnie)',
+        default=1,
+        validators=[Optional(), NumberRange(min=1, max=52)],
+    )
+    repeat_until = DateField(
+        'Powtarzaj do',
+        format='%Y-%m-%d',
+        validators=[Optional()],
+        render_kw={"placeholder": "rrrr-mm-dd"},
+    )
     submit = SubmitField('Zapisz')
+
+    def validate(self, extra_validators=None):
+        is_valid = super().validate(extra_validators=extra_validators)
+
+        if not is_valid:
+            return False
+
+        if self.repeat.data:
+            repeat_ok = True
+
+            if not self.repeat_interval.data:
+                self.repeat_interval.errors.append(
+                    'Podaj odstęp między treningami.'
+                )
+                repeat_ok = False
+
+            if not self.repeat_until.data:
+                self.repeat_until.errors.append('Podaj datę zakończenia powtórzeń.')
+                repeat_ok = False
+            elif self.date.data and self.repeat_until.data < self.date.data.date():
+                self.repeat_until.errors.append(
+                    'Data zakończenia musi być późniejsza niż początek.'
+                )
+                repeat_ok = False
+
+            return repeat_ok
+
+        return True
+
+    def iter_occurrences(self):
+        """Return a list of scheduled training datetimes based on the form."""
+
+        if not self.date.data:
+            return []
+
+        occurrences = [self.date.data]
+
+        if not (
+            self.repeat.data
+            and self.repeat_interval.data
+            and self.repeat_interval.data > 0
+            and self.repeat_until.data
+        ):
+            return occurrences
+
+        interval = timedelta(weeks=self.repeat_interval.data)
+        current = self.date.data
+
+        while True:
+            next_date = current + interval
+            if next_date.date() > self.repeat_until.data:
+                break
+            occurrences.append(next_date)
+            current = next_date
+
+        return occurrences
+
+    @property
+    def occurrence_count(self):
+        return len(self.iter_occurrences())
 
 
 class VolunteerForm(FlaskForm):

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -34,6 +34,39 @@
         <button class="btn btn-success">Dodaj trening</button>
       </div>
     </div>
+    <div class="row g-2 align-items-center mt-2">
+      <div class="col-auto">
+        <div class="form-check form-switch">
+          {{ form.repeat(class="form-check-input", id="repeat-toggle") }}
+          <label class="form-check-label" for="repeat-toggle">{{ form.repeat.label.text }}</label>
+        </div>
+      </div>
+      <div class="col-auto col-lg-2">
+        {{ form.repeat_interval.label(class="form-label mb-0") }}
+        {{ form.repeat_interval(class="form-control", min="1") }}
+      </div>
+      <div class="col-auto col-lg-2">
+        {{ form.repeat_until.label(class="form-label mb-0") }}
+        {{ form.repeat_until(class="form-control") }}
+      </div>
+      <div class="col-auto">
+        <div class="small text-muted">
+          Łącznie wystąpień: <strong>{{ form.occurrence_count }}</strong>
+        </div>
+      </div>
+    </div>
+    {% if repeat_feedback %}
+      <div class="alert alert-{{ repeat_feedback.category }} mt-3 mb-0">
+        <div>{{ repeat_feedback.message }}</div>
+        {% if repeat_feedback.skipped %}
+          <ul class="mb-0 small">
+            {% for conflict in repeat_feedback.skipped %}
+              <li>Pominięto {{ conflict }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    {% endif %}
   </form>
 
   {% for month, ts in trainings_by_month.items() %}


### PR DESCRIPTION
## Summary
- extend the training form with repeat controls, validation, and occurrence counting helpers
- generate repeated training instances in the admin view while skipping conflicts and surfacing summary feedback
- update the admin trainings template with repeat options, occurrence counts, and conflict feedback messaging

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3107593c8832a9f6a259a71d5f8be