### PR TITLE
Add training series tracking for scheduled trainings

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -24,6 +24,31 @@ class Location(db.Model):
         return f"<Location {self.name}>"
 
 
+class TrainingSeries(db.Model):
+    __tablename__ = 'training_series'
+
+    id = db.Column(db.Integer, primary_key=True)
+    created_at = db.Column(
+        db.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    start_date = db.Column(db.DateTime(timezone=True), nullable=False)
+    repeat = db.Column(db.Boolean, nullable=False, default=False)
+    repeat_interval_weeks = db.Column(db.Integer, nullable=True)
+    repeat_until = db.Column(db.Date, nullable=True)
+    planned_count = db.Column(db.Integer, nullable=False, default=0)
+    created_count = db.Column(db.Integer, nullable=False, default=0)
+    skipped_dates = db.Column(db.JSON, nullable=False, default=list)
+    coach_id = db.Column(db.Integer, db.ForeignKey('coaches.id'), nullable=False)
+    location_id = db.Column(db.Integer, db.ForeignKey('locations.id'), nullable=False)
+    max_volunteers = db.Column(db.Integer, nullable=False)
+
+    coach = db.relationship('Coach', backref=db.backref('training_series', lazy=True))
+    location = db.relationship('Location', backref=db.backref('training_series', lazy=True))
+    trainings = db.relationship('Training', back_populates='series', lazy=True)
+
+
 class Training(db.Model):
     __tablename__ = 'trainings'
     id = db.Column(db.Integer, primary_key=True)
@@ -37,6 +62,11 @@ class Training(db.Model):
         db.Integer,
         db.ForeignKey('coaches.id'),
         nullable=False,
+    )
+    series_id = db.Column(
+        db.Integer,
+        db.ForeignKey('training_series.id'),
+        nullable=True,
     )
     is_canceled = db.Column(
         db.Boolean,
@@ -70,6 +100,10 @@ class Training(db.Model):
     location = db.relationship(
         'Location',
         backref=db.backref('trainings', lazy=True),
+    )
+    series = db.relationship(
+        'TrainingSeries',
+        back_populates='trainings',
     )
 
     def __repr__(self):

--- a/migrations/versions/0f8f42b67d12_add_training_series.py
+++ b/migrations/versions/0f8f42b67d12_add_training_series.py
@@ -1,0 +1,58 @@
+"""add training series table
+
+Revision ID: 0f8f42b67d12
+Revises: 6a564e5cf48a
+Create Date: 2024-05-04 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0f8f42b67d12'
+down_revision = '6a564e5cf48a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'training_series',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('start_date', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('repeat', sa.Boolean(), nullable=False),
+        sa.Column('repeat_interval_weeks', sa.Integer(), nullable=True),
+        sa.Column('repeat_until', sa.Date(), nullable=True),
+        sa.Column('planned_count', sa.Integer(), nullable=False),
+        sa.Column('created_count', sa.Integer(), nullable=False),
+        sa.Column('skipped_dates', sa.JSON(), nullable=False),
+        sa.Column('coach_id', sa.Integer(), nullable=False),
+        sa.Column('location_id', sa.Integer(), nullable=False),
+        sa.Column('max_volunteers', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['coach_id'], ['coaches.id']),
+        sa.ForeignKeyConstraint(['location_id'], ['locations.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.add_column(
+        'trainings',
+        sa.Column('series_id', sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        'fk_trainings_series_id_training_series',
+        'trainings',
+        'training_series',
+        ['series_id'],
+        ['id'],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        'fk_trainings_series_id_training_series',
+        'trainings',
+        type_='foreignkey',
+    )
+    op.drop_column('trainings', 'series_id')
+    op.drop_table('training_series')


### PR DESCRIPTION
## Summary
- add a TrainingSeries model and link trainings to series metadata
- persist series details when scheduling trainings and assign the series to new sessions
- extend admin scheduling tests to ensure series identifiers and metadata are stored

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d314b36760832a87bf2ffd64b6473d