### PR TITLE
Add series summary schedule to admin trainings

### DIFF
--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -69,6 +69,53 @@
     {% endif %}
   </form>
 
+  <h4 class="mt-4">Harmonogram</h4>
+  <div class="table-responsive">
+    <table class="table table-striped table-sm align-middle">
+      <thead>
+        <tr>
+          <th>Dzień tygodnia</th>
+          <th>Godzina</th>
+          <th>Trener</th>
+          <th>Miejsce</th>
+          <th>Liczba treningów</th>
+          <th>Zakres dat</th>
+          <th class="text-end">Akcje</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% if series_summary %}
+          {% for series in series_summary %}
+            <tr>
+              <td>{{ series.weekday_label }}</td>
+              <td>{{ series.time_label }}</td>
+              <td>{{ series.coach_name }}</td>
+              <td>{{ series.location_name }}</td>
+              <td>{{ series.count }}</td>
+              <td>
+                {{ series.first_date.strftime('%Y-%m-%d') }} –
+                {{ series.last_date.strftime('%Y-%m-%d') }}
+              </td>
+              <td class="text-end">
+                <a href="{{ url_for('admin.edit_series', series_key=series.series_key) }}" class="btn btn-sm btn-outline-primary me-1">
+                  Edytuj
+                </a>
+                <form method="post" action="{{ url_for('admin.delete_series', series_key=series.series_key) }}" class="d-inline">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button class="btn btn-sm btn-outline-danger">Usuń</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        {% else %}
+          <tr>
+            <td colspan="7" class="text-center text-muted">Brak zaplanowanych treningów.</td>
+          </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+
   {% for month, ts in trainings_by_month.items() %}
   <h4 class="mt-4">{{ month|replace("-", " / ") }}</h4>
   <table class="table table-striped table-sm">


### PR DESCRIPTION
## Summary
- aggregate upcoming trainings by weekday, time, coach and location to build series summary in the admin view
- render a new "Harmonogram" table showing schedule statistics and action buttons
- add placeholder routes for editing and deleting training series so the new links resolve

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d316db41d8832abf5e2bc987232cdf