### PR TITLE
Add schedule series management routes and tests

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -185,6 +185,25 @@ class CancelForm(FlaskForm):
     submit = SubmitField('Wypisz się')
 
 
+class ScheduleSeriesForm(FlaskForm):
+    """Form for editing schedule series details."""
+
+    time = TimeField('Godzina', format='%H:%M', validators=[InputRequired()])
+    coach_id = SelectField('Trener', coerce=int, validators=[DataRequired()])
+    location_id = SelectField('Miejsce', coerce=int, validators=[DataRequired()])
+    max_volunteers = IntegerField(
+        'Limit miejsc', validators=[DataRequired(), NumberRange(min=1, max=20)]
+    )
+    submit = SubmitField('Zapisz zmiany')
+
+
+class ConfirmSeriesDeletionForm(FlaskForm):
+    """Form requiring confirmation before deleting a series."""
+
+    confirm = BooleanField('Potwierdzam usunięcie serii', validators=[DataRequired()])
+    submit = SubmitField('Usuń serię')
+
+
 class SettingsForm(FlaskForm):
     """Form for configuring email settings."""
 

--- a/app/templates/admin/schedule_delete.html
+++ b/app/templates/admin/schedule_delete.html
@@ -1,0 +1,21 @@
+{% extends "admin/admin_base.html" %}
+{% block admin_content %}
+<div class="container mt-4">
+  <h2>Usuń serię treningów</h2>
+  <div class="alert alert-warning">
+    Usunięcie serii oznaczy wszystkie powiązane treningi jako usunięte i ukryje je z harmonogramu.
+  </div>
+  <form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="form-check mb-3">
+      {{ form.confirm(class="form-check-input", id="confirm-delete") }}
+      <label class="form-check-label" for="confirm-delete">{{ form.confirm.label.text }}</label>
+    </div>
+    {% if form.confirm.errors %}
+      <div class="alert alert-danger">{{ form.confirm.errors[0] }}</div>
+    {% endif %}
+    <button class="btn btn-danger">Usuń serię</button>
+    <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-secondary ms-2">Anuluj</a>
+  </form>
+</div>
+{% endblock %}

--- a/app/templates/admin/schedule_edit.html
+++ b/app/templates/admin/schedule_edit.html
@@ -1,0 +1,45 @@
+{% extends "admin/admin_base.html" %}
+{% block admin_content %}
+<div class="container mt-4">
+  <h2>Edytuj serię treningów</h2>
+  <p class="text-muted">
+    Seria obejmuje {{ trainings|length }} treningów rozpoczynających się
+    {{ trainings[0].date.strftime('%Y-%m-%d') }}.
+  </p>
+  <form method="POST" class="mb-4">
+    {{ form.hidden_tag() }}
+    <div class="row g-2 align-items-end row-cols-lg-auto">
+      <div class="col-auto">
+        {{ form.time.label(class="form-label") }}
+        {{ form.time(class="form-control") }}
+      </div>
+      <div class="col-auto col-lg-3">
+        {{ form.coach_id.label(class="form-label") }}
+        {{ form.coach_id(class="form-select") }}
+      </div>
+      <div class="col-auto col-lg-3">
+        {{ form.location_id.label(class="form-label") }}
+        {{ form.location_id(class="form-select") }}
+      </div>
+      <div class="col-auto">
+        {{ form.max_volunteers.label(class="form-label") }}
+        {{ form.max_volunteers(class="form-control") }}
+      </div>
+      <div class="col-auto">
+        <button class="btn btn-primary">Zapisz zmiany</button>
+        <a href="{{ url_for('admin.manage_trainings') }}" class="btn btn-secondary ms-2">Anuluj</a>
+      </div>
+    </div>
+  </form>
+
+  <h5>Treningi w serii</h5>
+  <ul class="list-group list-group-flush">
+    {% for training in trainings %}
+      <li class="list-group-item d-flex justify-content-between align-items-center">
+        <span>{{ training.date.strftime('%Y-%m-%d') }}</span>
+        <span class="text-muted">{{ training.date.strftime('%H:%M') }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/tests/test_admin_schedule.py
+++ b/tests/test_admin_schedule.py
@@ -1,0 +1,185 @@
+from datetime import date, datetime
+
+import pytest
+
+from app import db
+from app.models import Coach, Location, Training, TrainingSeries
+
+
+@pytest.fixture
+def series_setup(app_instance):
+    with app_instance.app_context():
+        coach_one = Coach(first_name="Adam", last_name="Alpha", phone_number="111")
+        coach_two = Coach(first_name="Beata", last_name="Beta", phone_number="222")
+        location_one = Location(name="Sala A")
+        location_two = Location(name="Sala B")
+        db.session.add_all([coach_one, coach_two, location_one, location_two])
+        db.session.commit()
+
+        series = TrainingSeries(
+            start_date=datetime(2024, 1, 5, 18, 0),
+            repeat=True,
+            repeat_interval_weeks=1,
+            repeat_until=date(2024, 1, 12),
+            planned_count=2,
+            created_count=2,
+            coach_id=coach_one.id,
+            location_id=location_one.id,
+            max_volunteers=4,
+        )
+        db.session.add(series)
+        db.session.flush()
+
+        first_training = Training(
+            date=datetime(2024, 1, 5, 18, 0),
+            coach_id=coach_one.id,
+            location_id=location_one.id,
+            max_volunteers=4,
+            series_id=series.id,
+        )
+        second_training = Training(
+            date=datetime(2024, 1, 12, 18, 0),
+            coach_id=coach_one.id,
+            location_id=location_one.id,
+            max_volunteers=4,
+            series_id=series.id,
+        )
+        conflicting_training = Training(
+            date=datetime(2024, 1, 12, 19, 30),
+            coach_id=coach_two.id,
+            location_id=location_two.id,
+            max_volunteers=3,
+        )
+        db.session.add_all([first_training, second_training, conflicting_training])
+        db.session.commit()
+
+        yield {
+            "series_id": series.id,
+            "coach_one": coach_one.id,
+            "coach_two": coach_two.id,
+            "location_one": location_one.id,
+            "location_two": location_two.id,
+            "first_training": first_training.id,
+            "second_training": second_training.id,
+            "conflict_training": conflicting_training.id,
+        }
+
+
+def test_edit_series_updates_trainings_and_reports_conflicts(
+    client, app_instance, series_setup
+):
+    login = client.post(
+        "/admin/login", data={"password": "secret"}, follow_redirects=True
+    )
+    assert login.status_code == 200
+
+    series_id = series_setup["series_id"]
+    new_data = {
+        "time": "19:30",
+        "coach_id": str(series_setup["coach_two"]),
+        "location_id": str(series_setup["location_two"]),
+        "max_volunteers": "6",
+    }
+
+    response = client.post(
+        f"/admin/schedule/{series_id}/edit",
+        data=new_data,
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Zaktualizowano 1 z 2 treningów serii." in page
+    assert "Pominięto 2024-01-12 19:30 z powodu kolizji." in page
+
+    with app_instance.app_context():
+        updated_first = db.session.get(Training, series_setup["first_training"])
+        skipped_second = db.session.get(Training, series_setup["second_training"])
+        conflict = db.session.get(Training, series_setup["conflict_training"])
+        series = db.session.get(TrainingSeries, series_id)
+
+        assert updated_first.date == datetime(2024, 1, 5, 19, 30)
+        assert updated_first.coach_id == series_setup["coach_two"]
+        assert updated_first.location_id == series_setup["location_two"]
+        assert updated_first.max_volunteers == 6
+
+        assert skipped_second.date == datetime(2024, 1, 12, 18, 0)
+        assert skipped_second.coach_id == series_setup["coach_one"]
+        assert skipped_second.location_id == series_setup["location_one"]
+
+        assert conflict.date == datetime(2024, 1, 12, 19, 30)
+        assert conflict.location_id == series_setup["location_two"]
+
+        assert series.coach_id == series_setup["coach_two"]
+        assert series.location_id == series_setup["location_two"]
+        assert series.max_volunteers == 6
+        assert series.start_date == datetime(2024, 1, 5, 19, 30)
+
+
+def test_delete_series_marks_trainings_as_deleted(client, app_instance):
+    with app_instance.app_context():
+        coach = Coach(first_name="Olga", last_name="Omega", phone_number="444")
+        location = Location(name="Sala C")
+        db.session.add_all([coach, location])
+        db.session.commit()
+
+        series = TrainingSeries(
+            start_date=datetime(2024, 2, 1, 17, 0),
+            repeat=False,
+            planned_count=3,
+            created_count=3,
+            coach_id=coach.id,
+            location_id=location.id,
+            max_volunteers=2,
+        )
+        db.session.add(series)
+        db.session.flush()
+
+        trainings = [
+            Training(
+                date=datetime(2024, 2, 1, 17, 0),
+                coach_id=coach.id,
+                location_id=location.id,
+                max_volunteers=2,
+                series_id=series.id,
+            ),
+            Training(
+                date=datetime(2024, 2, 8, 17, 0),
+                coach_id=coach.id,
+                location_id=location.id,
+                max_volunteers=2,
+                series_id=series.id,
+            ),
+            Training(
+                date=datetime(2024, 2, 15, 17, 0),
+                coach_id=coach.id,
+                location_id=location.id,
+                max_volunteers=2,
+                series_id=series.id,
+                is_deleted=True,
+            ),
+        ]
+        db.session.add_all(trainings)
+        db.session.commit()
+
+        series_id = series.id
+        training_ids = [t.id for t in trainings]
+
+    login = client.post(
+        "/admin/login", data={"password": "secret"}, follow_redirects=True
+    )
+    assert login.status_code == 200
+
+    response = client.post(
+        f"/admin/schedule/{series_id}/delete",
+        data={"confirm": "y"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    page = response.get_data(as_text=True)
+    assert "Usunięto 2 treningów serii." in page
+
+    with app_instance.app_context():
+        trainings = [db.session.get(Training, tid) for tid in training_ids]
+        assert all(t.is_deleted for t in trainings)
+        series = db.session.get(TrainingSeries, series_id)
+        assert series.created_count == 0


### PR DESCRIPTION
## Summary
- add forms for editing and deleting training series
- implement admin schedule routes that update or remove entire series with collision messaging
- add templates and tests covering series edits with conflicts and deletions

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d317c44ff8832aaecf0080d2ccedd3