### PR TITLE
Use admin send_email alias

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -21,7 +21,8 @@ from . import db, csrf
 from . import email_utils
 
 # Alias retained for compatibility with tests that monkeypatch the function.
-send_email = email_utils.send_email
+def send_email(*args, **kwargs):
+    return email_utils.send_email(*args, **kwargs)
 from .template_utils import render_template_string
 from .forms import (
     CoachForm,
@@ -446,7 +447,7 @@ def cancel_training(training_id):
         html_body = f"Trening {data['date']} w {data['location']} został odwołany."
     recipients = [b.volunteer.email for b in training.bookings]
     if recipients:
-        success, error = email_utils.send_email(
+        success, error = send_email(
             subject, None, recipients, html_body=html_body
         )
         if not success:
@@ -1072,7 +1073,7 @@ def test_email():
                 )
             else:
                 try:
-                    success, error = email_utils.send_email(
+                    success, error = send_email(
                         "Test konfiguracji",
                         "To jest testowa wiadomość.",
                         [recipient],


### PR DESCRIPTION
## Summary
- wrap the admin `send_email` alias so it delegates to `email_utils.send_email`
- update admin routes to call the local alias when sending cancellation and test emails

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d31f502030832abeea12c1fd51c71e