### PR TITLE
Skip non-recurring trainings in schedule summary

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -324,6 +324,8 @@ def manage_trainings():
     ]
     series_map = {}
     for training in trainings:
+        if not training.series or not training.series.repeat:
+            continue
         date = training.date
         weekday = date.weekday()
         time_label = date.strftime("%H:%M")


### PR DESCRIPTION
## Summary
- skip trainings without recurring series when building the admin schedule summary

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32b72af1c832aa782bcf97596a460