### PR TITLE
Adjust training repeat UI and schedule handoff

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -499,6 +499,82 @@ def schedule():
         (loc.id, loc.name) for loc in Location.query.order_by(Location.name).all()
     ]
 
+    if flask.request.method == "GET" and flask.request.args:
+        initial_data = {}
+
+        start_date_arg = flask.request.args.get("start_date")
+        if start_date_arg:
+            try:
+                initial_data["start_date"] = datetime.strptime(
+                    start_date_arg, "%Y-%m-%d"
+                ).date()
+            except ValueError:
+                pass
+
+        start_time_arg = flask.request.args.get("start_time")
+        if start_time_arg:
+            for fmt in ("%H:%M", "%H:%M:%S"):
+                try:
+                    initial_data["start_time"] = datetime.strptime(
+                        start_time_arg, fmt
+                    ).time()
+                    break
+                except ValueError:
+                    continue
+
+        interval_arg = flask.request.args.get("interval_weeks")
+        if interval_arg:
+            try:
+                initial_data["interval_weeks"] = int(interval_arg)
+            except (TypeError, ValueError):
+                pass
+
+        end_date_arg = flask.request.args.get("end_date")
+        if end_date_arg:
+            try:
+                initial_data["end_date"] = datetime.strptime(
+                    end_date_arg, "%Y-%m-%d"
+                ).date()
+            except ValueError:
+                pass
+
+        days_args = flask.request.args.getlist("days")
+        if days_args:
+            cleaned_days = []
+            for value in days_args:
+                if value is None:
+                    continue
+                try:
+                    cleaned_days.append(str(int(value)))
+                except (TypeError, ValueError):
+                    continue
+            if cleaned_days:
+                initial_data["days"] = cleaned_days
+
+        location_arg = flask.request.args.get("location_id")
+        if location_arg:
+            try:
+                initial_data["location_id"] = int(location_arg)
+            except (TypeError, ValueError):
+                pass
+
+        coach_arg = flask.request.args.get("coach_id")
+        if coach_arg:
+            try:
+                initial_data["coach_id"] = int(coach_arg)
+            except (TypeError, ValueError):
+                pass
+
+        max_volunteers_arg = flask.request.args.get("max_volunteers")
+        if max_volunteers_arg:
+            try:
+                initial_data["max_volunteers"] = int(max_volunteers_arg)
+            except (TypeError, ValueError):
+                pass
+
+        if initial_data:
+            form.process(data=initial_data)
+
     planned_trainings = None
     skipped_collisions = []
 

--- a/app/templates/admin/trainings.html
+++ b/app/templates/admin/trainings.html
@@ -30,9 +30,6 @@
         {{ form.max_volunteers.label(class="form-label") }}
         {{ form.max_volunteers(class="form-control") }}
       </div>
-      <div class="col-auto">
-        <button class="btn btn-success">Dodaj trening</button>
-      </div>
     </div>
     <div class="row g-2 align-items-center mt-2">
       <div class="col-auto">
@@ -41,32 +38,50 @@
           <label class="form-check-label" for="repeat-toggle">{{ form.repeat.label.text }}</label>
         </div>
       </div>
-      <div class="col-auto col-lg-2">
-        {{ form.repeat_interval.label(class="form-label mb-0") }}
-        {{ form.repeat_interval(class="form-control", min="1") }}
-      </div>
-      <div class="col-auto col-lg-2">
-        {{ form.repeat_until.label(class="form-label mb-0") }}
-        {{ form.repeat_until(class="form-control") }}
-      </div>
-      <div class="col-auto">
-        <div class="small text-muted">
-          Łącznie wystąpień: <strong>{{ form.occurrence_count }}</strong>
+    </div>
+    <div id="repeat-section" class="mt-2{% if not form.repeat.data %} d-none{% endif %}">
+      <div class="row g-2 align-items-center" id="repeat-fields">
+        <div class="col-auto col-lg-2">
+          {{ form.repeat_interval.label(class="form-label mb-0") }}
+          {{ form.repeat_interval(class="form-control", min="1") }}
+        </div>
+        <div class="col-auto col-lg-2">
+          {{ form.repeat_until.label(class="form-label mb-0") }}
+          {{ form.repeat_until(class="form-control") }}
+        </div>
+        <div class="col-auto">
+          <div class="small text-muted">
+            Łącznie wystąpień: <strong id="occurrence-count">{{ form.occurrence_count }}</strong>
+          </div>
         </div>
       </div>
-    </div>
-    {% if repeat_feedback %}
-      <div class="alert alert-{{ repeat_feedback.category }} mt-3 mb-0">
-        <div>{{ repeat_feedback.message }}</div>
-        {% if repeat_feedback.skipped %}
-          <ul class="mb-0 small">
-            {% for conflict in repeat_feedback.skipped %}
-              <li>Pominięto {{ conflict }}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
+      <div class="mt-3 d-flex flex-wrap gap-2">
+        <button type="submit" class="btn btn-success">Dodaj pojedynczy trening</button>
+        <button
+          type="button"
+          class="btn btn-outline-primary{% if not form.repeat.data %} d-none{% endif %}"
+          id="schedule-button"
+          data-schedule-url="{{ url_for('admin.schedule') }}"
+        >
+          Dodaj harmonogram treningów
+        </button>
       </div>
-    {% endif %}
+      {% if repeat_feedback %}
+        <div class="alert alert-{{ repeat_feedback.category }} mt-3 mb-0">
+          <div>{{ repeat_feedback.message }}</div>
+          {% if repeat_feedback.skipped %}
+            <ul class="mb-0 small">
+              {% for conflict in repeat_feedback.skipped %}
+                <li>Pominięto {{ conflict }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+    <div class="mt-3{% if form.repeat.data %} d-none{% endif %}" id="single-submit-fallback">
+      <button type="submit" class="btn btn-success">Dodaj pojedynczy trening</button>
+    </div>
   </form>
 
   <h4 class="mt-4">Harmonogram</h4>
@@ -174,4 +189,5 @@
   </table>
   {% endfor %}
 </div>
+<script src="{{ url_for('static', filename='js/trainings_form.js') }}"></script>
 {% endblock %}

--- a/static/js/trainings_form.js
+++ b/static/js/trainings_form.js
@@ -1,0 +1,183 @@
+(function () {
+  function toNumber(value) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function toDate(value) {
+    if (!value) {
+      return null;
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  function calculateOccurrences({
+    repeatEnabled,
+    startValue,
+    intervalWeeks,
+    repeatUntilValue,
+  }) {
+    if (!repeatEnabled) {
+      return 1;
+    }
+
+    if (!startValue || !repeatUntilValue || !intervalWeeks || intervalWeeks <= 0) {
+      return null;
+    }
+
+    const [datePart, timePart = "00:00"] = startValue.split("T");
+    const startDate = toDate(`${datePart}T${timePart}`);
+    const repeatUntil = toDate(`${repeatUntilValue}T23:59:59`);
+
+    if (!startDate || !repeatUntil) {
+      return null;
+    }
+
+    let count = 1;
+    const current = new Date(startDate);
+
+    while (true) {
+      current.setDate(current.getDate() + intervalWeeks * 7);
+      if (current > repeatUntil) {
+        break;
+      }
+      count += 1;
+    }
+
+    return count;
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const repeatToggle = document.getElementById("repeat-toggle");
+    const repeatSection = document.getElementById("repeat-section");
+    const repeatFields = document.getElementById("repeat-fields");
+    const scheduleButton = document.getElementById("schedule-button");
+    const fallbackSubmit = document.getElementById("single-submit-fallback");
+    const occurrenceDisplay = document.getElementById("occurrence-count");
+    const dateField = document.getElementById("date");
+    const repeatIntervalField = document.getElementById("repeat_interval");
+    const repeatUntilField = document.getElementById("repeat_until");
+    const locationField = document.getElementById("location_id");
+    const coachField = document.getElementById("coach_id");
+    const maxVolunteersField = document.getElementById("max_volunteers");
+
+    function updateRepeatVisibility() {
+      if (!repeatToggle) {
+        return;
+      }
+      const enabled = repeatToggle.checked;
+
+      if (repeatSection) {
+        repeatSection.classList.toggle("d-none", !enabled);
+      }
+      if (repeatFields) {
+        repeatFields.classList.toggle("d-none", !enabled);
+      }
+      if (scheduleButton) {
+        scheduleButton.classList.toggle("d-none", !enabled);
+      }
+      if (fallbackSubmit) {
+        fallbackSubmit.classList.toggle("d-none", enabled);
+      }
+
+      updateOccurrenceCount();
+    }
+
+    function updateOccurrenceCount() {
+      if (!occurrenceDisplay) {
+        return;
+      }
+
+      const intervalWeeks = toNumber(repeatIntervalField ? repeatIntervalField.value : null);
+      const startValue = dateField ? dateField.value : null;
+      const repeatUntilValue = repeatUntilField ? repeatUntilField.value : null;
+      const repeatEnabled = repeatToggle ? repeatToggle.checked : false;
+
+      const occurrences = calculateOccurrences({
+        repeatEnabled,
+        startValue,
+        intervalWeeks,
+        repeatUntilValue,
+      });
+
+      occurrenceDisplay.textContent = occurrences === null ? "–" : String(occurrences);
+    }
+
+    function buildScheduleUrl() {
+      if (!scheduleButton) {
+        return null;
+      }
+      const baseUrl = scheduleButton.getAttribute("data-schedule-url");
+      if (!baseUrl) {
+        return null;
+      }
+
+      const url = new URL(baseUrl, window.location.origin);
+
+      if (dateField && dateField.value) {
+        const [startDatePart, startTimePart = ""] = dateField.value.split("T");
+        if (startDatePart) {
+          url.searchParams.set("start_date", startDatePart);
+          const weekday = toDate(`${startDatePart}T00:00:00`);
+          if (weekday) {
+            const pythonWeekday = (weekday.getDay() + 6) % 7;
+            url.searchParams.append("days", String(pythonWeekday));
+          }
+        }
+        if (startTimePart) {
+          url.searchParams.set("start_time", startTimePart);
+        }
+      }
+
+      if (repeatIntervalField && repeatIntervalField.value) {
+        url.searchParams.set("interval_weeks", repeatIntervalField.value);
+      }
+
+      if (repeatUntilField && repeatUntilField.value) {
+        url.searchParams.set("end_date", repeatUntilField.value);
+      }
+
+      if (locationField && locationField.value) {
+        url.searchParams.set("location_id", locationField.value);
+      }
+
+      if (coachField && coachField.value) {
+        url.searchParams.set("coach_id", coachField.value);
+      }
+
+      if (maxVolunteersField && maxVolunteersField.value) {
+        url.searchParams.set("max_volunteers", maxVolunteersField.value);
+      }
+
+      return url;
+    }
+
+    if (repeatToggle) {
+      repeatToggle.addEventListener("change", updateRepeatVisibility);
+    }
+
+    const scheduleClickHandler = function (event) {
+      const url = buildScheduleUrl();
+      if (!url) {
+        return;
+      }
+      event.preventDefault();
+      window.location.href = url.toString();
+    };
+
+    if (scheduleButton) {
+      scheduleButton.addEventListener("click", scheduleClickHandler);
+    }
+
+    [dateField, repeatIntervalField, repeatUntilField].forEach(function (field) {
+      if (!field) {
+        return;
+      }
+      field.addEventListener("change", updateOccurrenceCount);
+      field.addEventListener("input", updateOccurrenceCount);
+    });
+
+    updateRepeatVisibility();
+  });
+})();


### PR DESCRIPTION
## Summary
- reorganize the training creation form so repeat options are collapsible, the primary submit button is renamed, and the new schedule button appears beside it
- add a client-side script to toggle repeat controls, recalculate occurrence totals, and redirect to schedule creation with the current form values
- allow the schedule view to prefill its form from query parameters provided by the trainings page handoff

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d32bcacc8c832a837bb2ab78e95057