### PR TITLE
Zamień biuro@ na treningi@ w kontaktach

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ WHATSAPP_TEST_PHONE=+48697495755
 # When 1, ALL WhatsApp is redirected to WHATSAPP_TEST_PHONE (do not leave on in prod)
 # WHATSAPP_FORCE_TEST_RECIPIENT=1
 # Monthly summary recipient (scheduler)
-COORDINATOR_EMAIL=mappel@op.pl
+COORDINATOR_EMAIL=treningi@widzimyinaczej.org.pl
 WAHA_API_KEY=
 WAHA_DASHBOARD_USERNAME=
 WAHA_DASHBOARD_PASSWORD=

--- a/app/ai_assistant.py
+++ b/app/ai_assistant.py
@@ -32,7 +32,7 @@ KONTEKST ORGANIZACJI:
 
 ZASADY:
 - Jeśli ktoś pyta o zapisy/rejestrację, kieruj na stronę: treningi.widzimyinaczej.org.pl
-- Jeśli ktoś pyta o kontakt z fundacją: biuro@widzimyinaczej.org.pl
+- Jeśli ktoś pyta o kontakt z fundacją: treningi@widzimyinaczej.org.pl
 - Jeśli ktoś pyta o godziny/lokalizacje treningów, podaj informacje z kontekstu (jeśli dostępne)
 - NIE potwierdzaj ani nie odwołuj treningów - to robi system automatycznie na komendę POTWIERDZAM/REZYGNUJĘ
 - Jeśli ktoś chce potwierdzić/odwołać ale pisze niestandardowo, podpowiedz żeby napisał POTWIERDZAM lub REZYGNUJĘ

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -33,7 +33,7 @@
       </a>
       <div class="d-none d-md-flex align-items-center gap-3 small text-muted me-auto ms-4">
         <span><i class="bi bi-person-badge-fill me-1"></i>Koordynator:
-          <a href="mailto:mappel@op.pl" class="header-coordinator-link">Mariusz Appel</a>
+          <a href="mailto:treningi@widzimyinaczej.org.pl" class="header-coordinator-link">Mariusz Appel</a>
           &nbsp;&middot;&nbsp;
           <a href="tel:+48600987641" class="header-coordinator-link">600&nbsp;987&nbsp;641</a>
         </span>
@@ -94,7 +94,7 @@
         </a>
         <div>
           <i class="bi bi-person-badge-fill me-1"></i>
-          Koordynator:&nbsp;<a href="mailto:mappel@op.pl">Mariusz Appel</a>&nbsp;&middot;&nbsp;<a href="tel:+48600987641">600&nbsp;987&nbsp;641</a>
+          Koordynator:&nbsp;<a href="mailto:treningi@widzimyinaczej.org.pl">Mariusz Appel</a>&nbsp;&middot;&nbsp;<a href="tel:+48600987641">600&nbsp;987&nbsp;641</a>
         </div>
         <div>
           <i class="bi bi-envelope-fill me-1"></i>
@@ -130,7 +130,7 @@
           <a href="https://widzimyinaczej.org.pl/polityka-prywatnosci/" target="_blank"><i class="bi bi-shield-check"></i> Prywatność</a>
         </div>
         <div class="mt-2 small text-muted">
-          <i class="bi bi-person-badge-fill me-1"></i>Koordynator: <a href="mailto:mappel@op.pl">Mariusz Appel</a> &middot; <a href="tel:+48600987641">600 987 641</a>
+          <i class="bi bi-person-badge-fill me-1"></i>Koordynator: <a href="mailto:treningi@widzimyinaczej.org.pl">Mariusz Appel</a> &middot; <a href="tel:+48600987641">600 987 641</a>
         </div>
       </div>
     </div>

--- a/app/templates/update_phone.html
+++ b/app/templates/update_phone.html
@@ -107,7 +107,7 @@
         <i class="bi bi-exclamation-triangle-fill"></i>
         <h3>{{ error }}</h3>
         <p class="text-muted">Jeśli potrzebujesz pomocy, skontaktuj się z nami.</p>
-        <a href="mailto:biuro@widzimyinaczej.org.pl" class="btn btn-outline-primary mt-3">
+        <a href="mailto:treningi@widzimyinaczej.org.pl" class="btn btn-outline-primary mt-3">
           <i class="bi bi-envelope me-2"></i>Napisz do nas
         </a>
       </div>

--- a/app/webhook_routes.py
+++ b/app/webhook_routes.py
@@ -371,14 +371,14 @@ def send_unknown_response(
     if coach and not volunteer:
         fallback = (
             "Cześć! Ten bot służy głównie wolontariuszom do potwierdzania treningów.\n\n"
-            "Jeśli potrzebujesz pomocy, napisz do nas: biuro@widzimyinaczej.org.pl"
+            "Jeśli potrzebujesz pomocy, napisz do nas: treningi@widzimyinaczej.org.pl"
         )
     else:
         fallback = (
             "Dostępne komendy:\n"
             "✅ POTWIERDZAM - potwierdź udział w treningu\n"
             "❌ REZYGNUJĘ - zrezygnuj z treningu\n\n"
-            "Jeśli potrzebujesz pomocy, napisz do nas: biuro@widzimyinaczej.org.pl"
+            "Jeśli potrzebujesz pomocy, napisz do nas: treningi@widzimyinaczej.org.pl"
         )
     send_whatsapp_message('', fallback, chat_id=chat_id)
 
@@ -523,7 +523,7 @@ def whatsapp_webhook():
                     '',
                     "Ten bot służy wolontariuszom do potwierdzania udziału w treningach "
                     "(POTWIERDZAM / REZYGNUJĘ).\n\n"
-                    "Jeśli potrzebujesz pomocy, napisz: biuro@widzimyinaczej.org.pl",
+                    "Jeśli potrzebujesz pomocy, napisz: treningi@widzimyinaczej.org.pl",
                     chat_id=chat_id,
                 )
                 return jsonify({'status': 'ok', 'action': 'coach_command_hint'}), 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - WHATSAPP_SESSION=default
       - WHATSAPP_API_KEY=${WAHA_API_KEY}
       - WAHA_API_KEY=${WAHA_API_KEY}
-      - COORDINATOR_EMAIL=${COORDINATOR_EMAIL:-mappel@op.pl}
+      - COORDINATOR_EMAIL=${COORDINATOR_EMAIL:-treningi@widzimyinaczej.org.pl}
     env_file:
       - .env
     command: ["supercronic", "-passthrough-logs", "/app/scripts/crontab"]

--- a/scripts/crontab
+++ b/scripts/crontab
@@ -12,4 +12,4 @@
 */1 * * * * /app/scripts/waha_healthcheck.sh
 
 # Monthly coach Excel summaries on last day of month (21:00 Warsaw)
-0 21 28-31 * * [ "$(date -d tomorrow +\%d)" = "01" ] && cd /app && flask send-monthly-summary --coordinator-email ${COORDINATOR_EMAIL:-mappel@op.pl}
+0 21 28-31 * * [ "$(date -d tomorrow +\%d)" = "01" ] && cd /app && flask send-monthly-summary --coordinator-email ${COORDINATOR_EMAIL:-treningi@widzimyinaczej.org.pl}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Zmiana
Wszystkie kontakty `biuro@` oraz mail Mariusza Appela (`mappel@op.pl`) jako koordynatora wskazują teraz na `treningi@widzimyinaczej.org.pl`.

### Strona
- header + stopka (desktop/mobile): `mailto:` przy „Mariusz Appel” → `treningi@`
- stopka kontaktowa już wcześniej miała `treningi@`

### Inne kontakty użytkownika
- WhatsApp fallbacki (`webhook_routes.py`)
- prompt AI (`ai_assistant.py`)
- strona aktualizacji telefonu (`update_phone.html`)

### Koordynator (domyślny adres)
- `.env.example`, `docker-compose.yml`, `scripts/crontab` → `COORDINATOR_EMAIL=treningi@...`

### Nieruszone
- migracja `g7h8i9j0k1l2` — historyczny seed e-maila trenera Appela w tabeli `coaches` (osobny adres do miesięcznych podsumowań dla trenera, nie kontakt na stronie). Na produkcji e-mail trenera w DB trzeba ewentualnie zmienić ręcznie w adminie, jeśli też ma iść na `treningi@`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1090343f-b17f-4c72-855f-10b15b64c304?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1090343f-b17f-4c72-855f-10b15b64c304&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

